### PR TITLE
Add live Site links to directory tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,23 @@ Welcome to my playground.
 ## Directory
 
 <!-- BEGIN DIRECTORY -->
-| Project | Description | Tags | Published | Updated |
-|---|---|---|---|---|
-| [typography](typography) | A playground to explore &amp; experiment in the world of typography. |  | Nov 2022 | Sep 2025 |
-| [captions](captions) | Experimenting with HTML5's baked in captions. |  | Jan 2023 | Sep 2025 |
-| [playground-chatbots](chatbots) | This is a playground to experiment with chatbots and live chat: traditional dialog chatbots, natural language processing and understanding (NLPs &amp; NLUs), large language models (LLMs), live chat integration and conversation design best practices in general. |  | Mar 2023 | Sep 2025 |
-| [Exit Modals Demo](exit-modals) |  |  | Apr 2023 | Sep 2025 |
-| [HTML Media Best Practices README](html-media-best-practices) |  |  | Jul 2023 | Sep 2025 |
-| [Currency Input](currency-input) |  |  | Sep 2024 | Sep 2025 |
-| [Tiny](tiny) |  | `generative` | Jun 2025 | Sep 2025 |
-| [Forms](forms) |  |  | Jul 2025 | Sep 2025 |
-| [ia-for-banking-for-ai](ia-for-banking-for-ai) | Exploring digital banking experience information architecture and artificial intelligence opportunities |  | Aug 2025 | Sep 2025 |
-| [Arrival](arrival) | An image generator and decoder for '[Heptapod B](https://www.youtube.com/watch?v=me9uliPVqeU)', the logogram alien language in the film [Arrival](https://www.youtube.com/watch?v=oGI9hSl0q-w) (2016) | `generative` | Aug 2025 | Sep 2025 |
-| [Microwave](microwave) | **Concept**: Upload a picture of a plate of food and calculate how long you should microwave the food to acheive perfectly hot, but not too hot, food. | `generative` | Sep 2025 | Sep 2025 |
-| [Shapes](shapes) | Generative shape experiments. | `generative` | Sep 2025 | Sep 2025 |
-| [Velocity — Textured v1.1.0](terminal-velocity) | **What's new** (for richer land texture): | `generative` | Sep 2025 | Mar 2026 |
-| [Rock and Bop](rock-and-bop) | A music maker for adults and kids. This folder is design-only for now; implementation can land here later when you are ready. | `generative` | Mar 2026 | Mar 2026 |
-| [Scravax Drift Derby (Georgia)](project-scravax) |  | `generative` | Mar 2026 | Mar 2026 |
+| Project | Site | Description | Tags | Published | Updated |
+|---|---|---|---|---|---|
+| [typography](./typography/) | [↗](https://jas0nmjames.github.io/playground/typography/) | A playground to explore &amp; experiment in the world of typography. |  | Nov 2022 | Sep 2025 |
+| [captions](./captions/) | [↗](https://jas0nmjames.github.io/playground/captions/) | Experimenting with HTML5's baked in captions. |  | Jan 2023 | Sep 2025 |
+| [playground-chatbots](./chatbots/) | [↗](https://jas0nmjames.github.io/playground/chatbots/) | This is a playground to experiment with chatbots and live chat: traditional dialog chatbots, natural language processing and understanding (NLPs &amp; NLUs), large language models (LLMs), live chat integration and conversation design best practices in general. |  | Mar 2023 | Sep 2025 |
+| [Exit Modals Demo](./exit-modals/) | [↗](https://jas0nmjames.github.io/playground/exit-modals/) |  |  | Apr 2023 | Sep 2025 |
+| [HTML Media Best Practices README](./html-media-best-practices/) | [↗](https://jas0nmjames.github.io/playground/html-media-best-practices/) |  |  | Jul 2023 | Sep 2025 |
+| [Currency Input](./currency-input/) | [↗](https://jas0nmjames.github.io/playground/currency-input/) |  |  | Sep 2024 | Sep 2025 |
+| [Tiny](./tiny/) | [↗](https://jas0nmjames.github.io/playground/tiny/) |  | `generative` | Jun 2025 | Sep 2025 |
+| [Forms](./forms/) | [↗](https://jas0nmjames.github.io/playground/forms/) |  |  | Jul 2025 | Sep 2025 |
+| [ia-for-banking-for-ai](./ia-for-banking-for-ai/) | [↗](https://jas0nmjames.github.io/playground/ia-for-banking-for-ai/) | Exploring digital banking experience information architecture and artificial intelligence opportunities |  | Aug 2025 | Sep 2025 |
+| [Arrival](./arrival/) | [↗](https://jas0nmjames.github.io/playground/arrival/) | An image generator and decoder for '[Heptapod B](https://www.youtube.com/watch?v=me9uliPVqeU)', the logogram alien language in the film [Arrival](https://www.youtube.com/watch?v=oGI9hSl0q-w) (2016) | `generative` | Aug 2025 | Sep 2025 |
+| [Microwave](./microwave/) | [↗](https://jas0nmjames.github.io/playground/microwave/) | **Concept**: Upload a picture of a plate of food and calculate how long you should microwave the food to acheive perfectly hot, but not too hot, food. | `generative` | Sep 2025 | Sep 2025 |
+| [Shapes](./shapes/) | [↗](https://jas0nmjames.github.io/playground/shapes/) | Generative shape experiments. | `generative` | Sep 2025 | Sep 2025 |
+| [Velocity — Textured v1.1.0](./terminal-velocity/) | [↗](https://jas0nmjames.github.io/playground/terminal-velocity/) | **What's new** (for richer land texture): | `generative` | Sep 2025 | Mar 2026 |
+| [Rock and Bop](./rock-and-bop/) | [↗](https://jas0nmjames.github.io/playground/rock-and-bop/) | A music maker for adults and kids. This folder is design-only for now; implementation can land here later when you are ready. | `generative` | Mar 2026 | Mar 2026 |
+| [Scravax Drift Derby (Georgia)](./project-scravax/) | [↗](https://project-scravax.netlify.app/) |  | `generative` | Mar 2026 | Mar 2026 |
 <!-- END DIRECTORY -->
 
 ## Generative Experiments
@@ -32,15 +32,15 @@ Welcome to my playground.
 Building things I couldn't before, [at great expense](https://www.youtube.com/watch?v=8enXRDlWguU "YouTube - Novara Media: Aaron Bastani Meets Karen Hao").
 
 <!-- BEGIN GENERATIVE -->
-| Project | Description | Tags | Published | Updated |
-|---|---|---|---|---|
-| [Tiny](tiny) |  | `generative` | Jun 2025 | Sep 2025 |
-| [Arrival](arrival) | An image generator and decoder for '[Heptapod B](https://www.youtube.com/watch?v=me9uliPVqeU)', the logogram alien language in the film [Arrival](https://www.youtube.com/watch?v=oGI9hSl0q-w) (2016) | `generative` | Aug 2025 | Sep 2025 |
-| [Microwave](microwave) | **Concept**: Upload a picture of a plate of food and calculate how long you should microwave the food to acheive perfectly hot, but not too hot, food. | `generative` | Sep 2025 | Sep 2025 |
-| [Shapes](shapes) | Generative shape experiments. | `generative` | Sep 2025 | Sep 2025 |
-| [Velocity — Textured v1.1.0](terminal-velocity) | **What's new** (for richer land texture): | `generative` | Sep 2025 | Mar 2026 |
-| [Rock and Bop](rock-and-bop) | A music maker for adults and kids. This folder is design-only for now; implementation can land here later when you are ready. | `generative` | Mar 2026 | Mar 2026 |
-| [Scravax Drift Derby (Georgia)](project-scravax) |  | `generative` | Mar 2026 | Mar 2026 |
+| Project | Site | Description | Tags | Published | Updated |
+|---|---|---|---|---|---|
+| [Tiny](./tiny/) | [↗](https://jas0nmjames.github.io/playground/tiny/) |  | `generative` | Jun 2025 | Sep 2025 |
+| [Arrival](./arrival/) | [↗](https://jas0nmjames.github.io/playground/arrival/) | An image generator and decoder for '[Heptapod B](https://www.youtube.com/watch?v=me9uliPVqeU)', the logogram alien language in the film [Arrival](https://www.youtube.com/watch?v=oGI9hSl0q-w) (2016) | `generative` | Aug 2025 | Sep 2025 |
+| [Microwave](./microwave/) | [↗](https://jas0nmjames.github.io/playground/microwave/) | **Concept**: Upload a picture of a plate of food and calculate how long you should microwave the food to acheive perfectly hot, but not too hot, food. | `generative` | Sep 2025 | Sep 2025 |
+| [Shapes](./shapes/) | [↗](https://jas0nmjames.github.io/playground/shapes/) | Generative shape experiments. | `generative` | Sep 2025 | Sep 2025 |
+| [Velocity — Textured v1.1.0](./terminal-velocity/) | [↗](https://jas0nmjames.github.io/playground/terminal-velocity/) | **What's new** (for richer land texture): | `generative` | Sep 2025 | Mar 2026 |
+| [Rock and Bop](./rock-and-bop/) | [↗](https://jas0nmjames.github.io/playground/rock-and-bop/) | A music maker for adults and kids. This folder is design-only for now; implementation can land here later when you are ready. | `generative` | Mar 2026 | Mar 2026 |
+| [Scravax Drift Derby (Georgia)](./project-scravax/) | [↗](https://project-scravax.netlify.app/) |  | `generative` | Mar 2026 | Mar 2026 |
 <!-- END GENERATIVE -->
 
 ## Maintaining the Directory
@@ -57,8 +57,11 @@ The Directory and Generative Experiments tables are auto-generated by `scripts/b
 published: YYYY-MM-DD
 updated: YYYY-MM-DD
 tags: generative        # optional — omit if not a generative experiment
+url: https://example.com  # optional — only needed if deployed somewhere other than GitHub Pages
 ---
 ```
+
+By default the **Site** link in the directory table points to `https://jas0nmjames.github.io/playground/<folder>/`. Set `url` only if the project is deployed elsewhere (e.g. Netlify).
 
 3. Run the build script locally to update this README before committing:
 
@@ -86,11 +89,13 @@ Directory automation built with [Claude](https://claude.ai) (claude-sonnet-4-6) 
 
 - `scripts/build-readme.js` — reads each subfolder's frontmatter, sorts by `published` date, regenerates the Directory and Generative Experiments tables
 - `.github/workflows/update-readme.yml` — runs the build script automatically on push to `main`
-- Frontmatter schema (`published`, `updated`, `tags`) added to all subfolder READMEs
+- Frontmatter schema (`published`, `updated`, `tags`, `url`) added to all subfolder READMEs
 - Repo restructured from nested `generative-experiments/` subfolders to flat root-level structure
+- **Site column added** — each table row now links to both the project README and the live GitHub Pages (or external) URL; `url` frontmatter overrides the default GitHub Pages link (used for `project-scravax` → Netlify)
 
 | Created | Tool | Model | Estimated energy consumption[^claude] | Estimated carbon emissions | Estimated water usage |
 |---|---|---|---|---|---|
 | March 26, 2026 | Claude Code | claude-sonnet-4-6 | 0.54 kWh | 0.208 kg CO₂ | 0.27 L |
+| March 26, 2026 | Claude Code | claude-sonnet-4-6 | 0.09 kWh | 0.035 kg CO₂ | 0.045 L |
 
 [^claude]: assuming 18 Wh per prompt; does not include estimate for foundation model training

--- a/project-scravax/README.md
+++ b/project-scravax/README.md
@@ -2,6 +2,7 @@
 published: 2026-03-10
 updated: 2026-03-12
 tags: generative
+url: https://project-scravax.netlify.app/
 ---
 
 # Scravax Drift Derby (Georgia)

--- a/scripts/build-readme.js
+++ b/scripts/build-readme.js
@@ -16,6 +16,7 @@ const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..');
 const ROOT_README = path.join(ROOT, 'README.md');
+const GITHUB_PAGES_BASE = 'https://jas0nmjames.github.io/playground/';
 
 function parseFrontmatter(content) {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
@@ -64,17 +65,18 @@ function formatDate(dateStr) {
 
 function buildTable(projects) {
   const rows = projects.map(p => {
-    const name = `[${p.title}](${p.dir})`;
+    const readme = `[${p.title}](./${p.dir}/)`;
+    const site = `[↗](${p.siteUrl})`;
     const desc = p.description || '';
     const tag = p.tags.length ? p.tags.map(t => `\`${t}\``).join(' ') : '';
     const pub = formatDate(p.published);
     const upd = formatDate(p.updated);
-    return `| ${name} | ${desc} | ${tag} | ${pub} | ${upd} |`;
+    return `| ${readme} | ${site} | ${desc} | ${tag} | ${pub} | ${upd} |`;
   });
 
   return [
-    '| Project | Description | Tags | Published | Updated |',
-    '|---|---|---|---|---|',
+    '| Project | Site | Description | Tags | Published | Updated |',
+    '|---|---|---|---|---|---|',
     ...rows,
   ].join('\n');
 }
@@ -111,6 +113,8 @@ for (const dir of entries) {
   const title = extractTitle(body) || dir;
   const description = extractDescription(body);
   const tags = fm.tags ? fm.tags.split(',').map(t => t.trim()).filter(Boolean) : [];
+  // url: explicit frontmatter override (e.g. external deployment); otherwise GitHub Pages
+  const siteUrl = fm.url ? fm.url.trim() : `${GITHUB_PAGES_BASE}${dir}/`;
 
   projects.push({
     dir,
@@ -119,6 +123,7 @@ for (const dir of entries) {
     published: fm.published || null,
     updated: fm.updated || null,
     tags,
+    siteUrl,
   });
 }
 


### PR DESCRIPTION
Each row in the Directory and Generative Experiments tables now includes two links per project:
- Project name → relative link to the subfolder README (GitHub.com folder view)
- ↗ → full URL to the live site (GitHub Pages or external deployment)

Changes:
- scripts/build-readme.js: added GITHUB_PAGES_BASE constant; build-table now emits a Site column using the GitHub Pages URL by default, or the value of the optional `url` frontmatter field when set
- project-scravax/README.md: added `url: https://project-scravax.netlify.app/` so its Site link correctly points to the Netlify deployment instead of a GitHub Pages URL
- README.md: tables regenerated with new Site column; Maintaining the Directory docs updated to document the optional `url` frontmatter field and the default GitHub Pages URL behaviour; Claude section updated with new work summary and additional energy/carbon/water usage estimate