### PR TITLE
Add hub pages and fix all GitHub Pages site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Welcome to my playground.
 <!-- BEGIN DIRECTORY -->
 | Project | Site | Description | Tags | Published | Updated |
 |---|---|---|---|---|---|
-| [typography](./typography/) | [↗](https://jas0nmjames.github.io/playground/typography/) | A playground to explore &amp; experiment in the world of typography. |  | Nov 2022 | Sep 2025 |
+| [typography](./typography/) | [↗](https://jas0nmjames.github.io/playground/typography/bungee.html) | A playground to explore &amp; experiment in the world of typography. |  | Nov 2022 | Sep 2025 |
 | [captions](./captions/) | [↗](https://jas0nmjames.github.io/playground/captions/) | Experimenting with HTML5's baked in captions. |  | Jan 2023 | Sep 2025 |
 | [playground-chatbots](./chatbots/) | [↗](https://jas0nmjames.github.io/playground/chatbots/) | This is a playground to experiment with chatbots and live chat: traditional dialog chatbots, natural language processing and understanding (NLPs &amp; NLUs), large language models (LLMs), live chat integration and conversation design best practices in general. |  | Mar 2023 | Sep 2025 |
 | [Exit Modals Demo](./exit-modals/) | [↗](https://jas0nmjames.github.io/playground/exit-modals/) |  |  | Apr 2023 | Sep 2025 |
@@ -18,12 +18,12 @@ Welcome to my playground.
 | [Currency Input](./currency-input/) | [↗](https://jas0nmjames.github.io/playground/currency-input/) |  |  | Sep 2024 | Sep 2025 |
 | [Tiny](./tiny/) | [↗](https://jas0nmjames.github.io/playground/tiny/) |  | `generative` | Jun 2025 | Sep 2025 |
 | [Forms](./forms/) | [↗](https://jas0nmjames.github.io/playground/forms/) |  |  | Jul 2025 | Sep 2025 |
-| [ia-for-banking-for-ai](./ia-for-banking-for-ai/) | [↗](https://jas0nmjames.github.io/playground/ia-for-banking-for-ai/) | Exploring digital banking experience information architecture and artificial intelligence opportunities |  | Aug 2025 | Sep 2025 |
+| [ia-for-banking-for-ai](./ia-for-banking-for-ai/) | — | Exploring digital banking experience information architecture and artificial intelligence opportunities |  | Aug 2025 | Sep 2025 |
 | [Arrival](./arrival/) | [↗](https://jas0nmjames.github.io/playground/arrival/) | An image generator and decoder for '[Heptapod B](https://www.youtube.com/watch?v=me9uliPVqeU)', the logogram alien language in the film [Arrival](https://www.youtube.com/watch?v=oGI9hSl0q-w) (2016) | `generative` | Aug 2025 | Sep 2025 |
-| [Microwave](./microwave/) | [↗](https://jas0nmjames.github.io/playground/microwave/) | **Concept**: Upload a picture of a plate of food and calculate how long you should microwave the food to acheive perfectly hot, but not too hot, food. | `generative` | Sep 2025 | Sep 2025 |
+| [Microwave](./microwave/) | — | **Concept**: Upload a picture of a plate of food and calculate how long you should microwave the food to acheive perfectly hot, but not too hot, food. | `generative` | Sep 2025 | Sep 2025 |
 | [Shapes](./shapes/) | [↗](https://jas0nmjames.github.io/playground/shapes/) | Generative shape experiments. | `generative` | Sep 2025 | Sep 2025 |
 | [Velocity — Textured v1.1.0](./terminal-velocity/) | [↗](https://jas0nmjames.github.io/playground/terminal-velocity/) | **What's new** (for richer land texture): | `generative` | Sep 2025 | Mar 2026 |
-| [Rock and Bop](./rock-and-bop/) | [↗](https://jas0nmjames.github.io/playground/rock-and-bop/) | A music maker for adults and kids. This folder is design-only for now; implementation can land here later when you are ready. | `generative` | Mar 2026 | Mar 2026 |
+| [Rock and Bop](./rock-and-bop/) | — | A music maker for adults and kids. This folder is design-only for now; implementation can land here later when you are ready. | `generative` | Mar 2026 | Mar 2026 |
 | [Scravax Drift Derby (Georgia)](./project-scravax/) | [↗](https://project-scravax.netlify.app/) |  | `generative` | Mar 2026 | Mar 2026 |
 <!-- END DIRECTORY -->
 
@@ -36,10 +36,10 @@ Building things I couldn't before, [at great expense](https://www.youtube.com/wa
 |---|---|---|---|---|---|
 | [Tiny](./tiny/) | [↗](https://jas0nmjames.github.io/playground/tiny/) |  | `generative` | Jun 2025 | Sep 2025 |
 | [Arrival](./arrival/) | [↗](https://jas0nmjames.github.io/playground/arrival/) | An image generator and decoder for '[Heptapod B](https://www.youtube.com/watch?v=me9uliPVqeU)', the logogram alien language in the film [Arrival](https://www.youtube.com/watch?v=oGI9hSl0q-w) (2016) | `generative` | Aug 2025 | Sep 2025 |
-| [Microwave](./microwave/) | [↗](https://jas0nmjames.github.io/playground/microwave/) | **Concept**: Upload a picture of a plate of food and calculate how long you should microwave the food to acheive perfectly hot, but not too hot, food. | `generative` | Sep 2025 | Sep 2025 |
+| [Microwave](./microwave/) | — | **Concept**: Upload a picture of a plate of food and calculate how long you should microwave the food to acheive perfectly hot, but not too hot, food. | `generative` | Sep 2025 | Sep 2025 |
 | [Shapes](./shapes/) | [↗](https://jas0nmjames.github.io/playground/shapes/) | Generative shape experiments. | `generative` | Sep 2025 | Sep 2025 |
 | [Velocity — Textured v1.1.0](./terminal-velocity/) | [↗](https://jas0nmjames.github.io/playground/terminal-velocity/) | **What's new** (for richer land texture): | `generative` | Sep 2025 | Mar 2026 |
-| [Rock and Bop](./rock-and-bop/) | [↗](https://jas0nmjames.github.io/playground/rock-and-bop/) | A music maker for adults and kids. This folder is design-only for now; implementation can land here later when you are ready. | `generative` | Mar 2026 | Mar 2026 |
+| [Rock and Bop](./rock-and-bop/) | — | A music maker for adults and kids. This folder is design-only for now; implementation can land here later when you are ready. | `generative` | Mar 2026 | Mar 2026 |
 | [Scravax Drift Derby (Georgia)](./project-scravax/) | [↗](https://project-scravax.netlify.app/) |  | `generative` | Mar 2026 | Mar 2026 |
 <!-- END GENERATIVE -->
 

--- a/chatbots/index.html
+++ b/chatbots/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>playground-chatbots</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 680px; margin: 2.5rem auto; padding: 0 1.25rem; color: #1a1a1a; }
+    h1 { font-size: 1.75rem; margin-bottom: 0.25rem; }
+    .desc { color: #555; margin: 0 0 2rem; }
+    h2 { font-size: 0.875rem; text-transform: uppercase; letter-spacing: 0.05em; color: #888; margin: 1.5rem 0 0.5rem; }
+    ul { list-style: none; padding: 0; margin: 0; }
+    li { border-bottom: 1px solid #eee; }
+    li:last-child { border-bottom: none; }
+    a.demo { display: block; padding: 0.6rem 0; color: #0066cc; text-decoration: none; font-weight: 500; }
+    a.demo:hover { text-decoration: underline; }
+    .back { margin-top: 2.5rem; font-size: 0.875rem; }
+    .back a { color: #555; }
+  </style>
+</head>
+<body>
+  <h1>playground-chatbots</h1>
+  <p class="desc">Experiments with chatbot and live chat integrations: traditional dialog chatbots, NLPs, LLMs, and live chat widgets.</p>
+
+  <h2>Demos</h2>
+  <ul>
+    <li><a class="demo" href="tawkto.html">tawk.to — Live chat widget demo</a></li>
+    <li><a class="demo" href="tidio.html">Tidio — Live chat widget demo</a></li>
+  </ul>
+
+  <p class="back"><a href="https://github.com/jas0nmjames/playground/tree/main/chatbots">README on GitHub ↗</a></p>
+</body>
+</html>

--- a/exit-modals/index.html
+++ b/exit-modals/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Exit Modals Demo</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 680px; margin: 2.5rem auto; padding: 0 1.25rem; color: #1a1a1a; }
+    h1 { font-size: 1.75rem; margin-bottom: 0.25rem; }
+    .desc { color: #555; margin: 0 0 2rem; }
+    h2 { font-size: 0.875rem; text-transform: uppercase; letter-spacing: 0.05em; color: #888; margin: 1.5rem 0 0.5rem; }
+    ul { list-style: none; padding: 0; margin: 0; }
+    li { border-bottom: 1px solid #eee; }
+    li:last-child { border-bottom: none; }
+    a.demo { display: block; padding: 0.6rem 0; color: #0066cc; text-decoration: none; font-weight: 500; }
+    a.demo:hover { text-decoration: underline; }
+    .back { margin-top: 2.5rem; font-size: 0.875rem; }
+    .back a { color: #555; }
+  </style>
+</head>
+<body>
+  <h1>Exit Modals Demo</h1>
+  <p class="desc">Three iterations exploring exit intent modal patterns and new-tab interstitial approaches.</p>
+
+  <h2>First Iteration</h2>
+  <ul>
+    <li><a class="demo" href="first-iteration/">Exit Intent Modal</a></li>
+  </ul>
+
+  <h2>Second Iteration</h2>
+  <ul>
+    <li><a class="demo" href="second-iteration/best-practice/">Best Practice</a></li>
+    <li><a class="demo" href="second-iteration/new-tab-interstitial/">New Tab Interstitial</a></li>
+    <li><a class="demo" href="second-iteration/new-tab-interstitial-preferred/">New Tab Interstitial (Preferred)</a></li>
+  </ul>
+
+  <h2>Third Iteration</h2>
+  <ul>
+    <li><a class="demo" href="third-iteration/best-practice/">Best Practice</a></li>
+    <li><a class="demo" href="third-iteration/new-tab-interstitial/">New Tab Interstitial</a></li>
+    <li><a class="demo" href="third-iteration/new-tab-interstitial-preferred/">New Tab Interstitial (Preferred)</a></li>
+  </ul>
+
+  <p class="back"><a href="https://github.com/jas0nmjames/playground/tree/main/exit-modals">README on GitHub ↗</a></p>
+</body>
+</html>

--- a/forms/index.html
+++ b/forms/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Forms</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 680px; margin: 2.5rem auto; padding: 0 1.25rem; color: #1a1a1a; }
+    h1 { font-size: 1.75rem; margin-bottom: 0.25rem; }
+    .desc { color: #555; margin: 0 0 2rem; }
+    h2 { font-size: 0.875rem; text-transform: uppercase; letter-spacing: 0.05em; color: #888; margin: 1.5rem 0 0.5rem; }
+    ul { list-style: none; padding: 0; margin: 0; }
+    li { border-bottom: 1px solid #eee; }
+    li:last-child { border-bottom: none; }
+    a.demo { display: block; padding: 0.6rem 0; color: #0066cc; text-decoration: none; font-weight: 500; }
+    a.demo:hover { text-decoration: underline; }
+    .back { margin-top: 2.5rem; font-size: 0.875rem; }
+    .back a { color: #555; }
+  </style>
+</head>
+<body>
+  <h1>Forms</h1>
+  <p class="desc">KYC banking form experiments with JSON logic, multi-country support, and wizard patterns.</p>
+
+  <h2>Demos</h2>
+  <ul>
+    <li><a class="demo" href="form/">KYC Banking Questionnaire</a></li>
+    <li><a class="demo" href="form-multiple-countries/">KYC Banking Questionnaire — Multiple Countries</a></li>
+    <li><a class="demo" href="form-with-json-logic/">KYC Banking Questionnaire — JSON Logic</a></li>
+    <li><a class="demo" href="wizard-form-with-json-logic/">KYC Multi-Step Form with Review</a></li>
+  </ul>
+
+  <p class="back"><a href="https://github.com/jas0nmjames/playground/tree/main/forms">README on GitHub ↗</a></p>
+</body>
+</html>

--- a/html-media-best-practices/index.html
+++ b/html-media-best-practices/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>HTML Media Best Practices</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 680px; margin: 2.5rem auto; padding: 0 1.25rem; color: #1a1a1a; }
+    h1 { font-size: 1.75rem; margin-bottom: 0.25rem; }
+    .desc { color: #555; margin: 0 0 2rem; }
+    h2 { font-size: 0.875rem; text-transform: uppercase; letter-spacing: 0.05em; color: #888; margin: 1.5rem 0 0.5rem; }
+    ul { list-style: none; padding: 0; margin: 0; }
+    li { border-bottom: 1px solid #eee; }
+    li:last-child { border-bottom: none; }
+    a.demo { display: block; padding: 0.6rem 0; color: #0066cc; text-decoration: none; font-weight: 500; }
+    a.demo:hover { text-decoration: underline; }
+    .back { margin-top: 2.5rem; font-size: 0.875rem; }
+    .back a { color: #555; }
+  </style>
+</head>
+<body>
+  <h1>HTML Media Best Practices</h1>
+  <p class="desc">Experiments comparing image and video loading strategies: lazy loading, format support, poster images, and embed patterns.</p>
+
+  <h2>Images</h2>
+  <ul>
+    <li><a class="demo" href="01_one-image.html">One Image</a></li>
+    <li><a class="demo" href="three-images.html">Three Images</a></li>
+    <li><a class="demo" href="three-images-lazy-loaded.html">Three Images — Lazy Loaded</a></li>
+    <li><a class="demo" href="image-optimization_phase-1.html">Image Optimization — Phase 1</a></li>
+    <li><a class="demo" href="image-optimization_phase-2.html">Image Optimization — Phase 2</a></li>
+  </ul>
+
+  <h2>Videos</h2>
+  <ul>
+    <li><a class="demo" href="video-test-1a.html">Video Test 1a</a></li>
+    <li><a class="demo" href="video-test-1a_no-poster.html">Video Test 1a — No Poster</a></li>
+    <li><a class="demo" href="video-test-1a_no-poster_mp4-only.html">Video Test 1a — No Poster, MP4 Only</a></li>
+    <li><a class="demo" href="three-videos-no-lazy-loading.html">Three Videos — No Lazy Loading</a></li>
+    <li><a class="demo" href="three-videos-no-lazy-loading-no-poster.html">Three Videos — No Lazy Loading, No Poster</a></li>
+    <li><a class="demo" href="three-videos-lazy-loaded.html">Three Videos — Lazy Loaded</a></li>
+    <li><a class="demo" href="three-videos-lazy-loaded_no-webm.html">Three Videos — Lazy Loaded, No WebM</a></li>
+  </ul>
+
+  <h2>Embeds</h2>
+  <ul>
+    <li><a class="demo" href="vimeo-embed-testing.html">Vimeo Embed Testing</a></li>
+    <li><a class="demo" href="youtube-embed-testing.html">YouTube Embed Testing</a></li>
+  </ul>
+
+  <p class="back"><a href="https://github.com/jas0nmjames/playground/tree/main/html-media-best-practices">README on GitHub ↗</a></p>
+</body>
+</html>

--- a/ia-for-banking-for-ai/README.md
+++ b/ia-for-banking-for-ai/README.md
@@ -1,6 +1,7 @@
 ---
 published: 2025-08-04
 updated: 2025-09-02
+nosite: true
 ---
 
 # ia-for-banking-for-ai

--- a/microwave/README.md
+++ b/microwave/README.md
@@ -2,6 +2,7 @@
 published: 2025-09-02
 updated: 2025-09-02
 tags: generative
+nosite: true
 ---
 
 # Microwave

--- a/rock-and-bop/README.md
+++ b/rock-and-bop/README.md
@@ -2,6 +2,7 @@
 published: 2026-03-01
 updated: 2026-03-01
 tags: generative
+nosite: true
 ---
 
 # Rock and Bop

--- a/scripts/build-readme.js
+++ b/scripts/build-readme.js
@@ -66,7 +66,7 @@ function formatDate(dateStr) {
 function buildTable(projects) {
   const rows = projects.map(p => {
     const readme = `[${p.title}](./${p.dir}/)`;
-    const site = `[↗](${p.siteUrl})`;
+    const site = p.siteUrl ? `[↗](${p.siteUrl})` : '—';
     const desc = p.description || '';
     const tag = p.tags.length ? p.tags.map(t => `\`${t}\``).join(' ') : '';
     const pub = formatDate(p.published);
@@ -113,8 +113,10 @@ for (const dir of entries) {
   const title = extractTitle(body) || dir;
   const description = extractDescription(body);
   const tags = fm.tags ? fm.tags.split(',').map(t => t.trim()).filter(Boolean) : [];
+  // nosite: true → no live site link (docs/design-only projects)
+  const nosite = fm.nosite === 'true';
   // url: explicit frontmatter override (e.g. external deployment); otherwise GitHub Pages
-  const siteUrl = fm.url ? fm.url.trim() : `${GITHUB_PAGES_BASE}${dir}/`;
+  const siteUrl = nosite ? null : (fm.url ? fm.url.trim() : `${GITHUB_PAGES_BASE}${dir}/`);
 
   projects.push({
     dir,

--- a/typography/README.md
+++ b/typography/README.md
@@ -1,6 +1,7 @@
 ---
 published: 2022-11-01
 updated: 2025-09-02
+url: https://jas0nmjames.github.io/playground/typography/bungee.html
 ---
 
 # typography


### PR DESCRIPTION
Each project with interactive HTML content now has a working live site link in the directory table. Projects with no deployable HTML are correctly marked with — in the Site column.

New hub pages (index.html):
- chatbots/ — links to tawkto.html and tidio.html
- exit-modals/ — links across all three iterations and their variants
- forms/ — links to all four KYC form demos
- html-media-best-practices/ — links to all 14 image/video/embed demos, grouped by media type

Frontmatter updates:
- typography: url → direct link to bungee.html (only one demo page)
- ia-for-banking-for-ai, microwave, rock-and-bop: nosite: true (docs/ design-only, no deployable HTML)

Build script:
- Support for nosite: true frontmatter — renders — in Site column instead of a broken GitHub Pages link
- Site cell is now null-safe (no link generated when nosite is set)

README regenerated with updated Site links for all 15 projects.