### PR TITLE
feat(dut-dut): explain a pattern with your own assistant

### DIFF
--- a/dut-dut/.claude/launch.json
+++ b/dut-dut/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "dut-dut",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 5174
+      "port": 5174,
+      "autoPort": true
     }
   ]
 }

--- a/dut-dut/README.md
+++ b/dut-dut/README.md
@@ -49,7 +49,9 @@ The Insights panel explains patterns for free, offline, with no account and no A
 
 Three tiers, because the one-click path is the least reliable: **copy** works with anything including a local model, **deep links** prefill Claude / ChatGPT / Gemini when the payload fits in a URL (their `?q=` parameters are undocumented and can break, so anything too long copies and opens an empty chat rather than silently truncating), and **download .md** suits Projects, NotebookLM, or emailing a band director.
 
-Guardrails, not gates: you preview the exact text before it moves, a first-run notice explains what's shared, that it spends *your* credits, and that assistants set their own minimum ages (claude.ai is 18+, most others 13+ or parental consent). Nothing is blocked — you decide.
+Guardrails, not gates: you preview the exact text before it moves, and a first-run notice explains what's shared, that the cost falls on the assistant's free tier or your own account rather than the app's, and that assistants set their own minimum ages (claude.ai is 18+, most others 13+ or parental consent). Nothing is blocked — you decide.
+
+Verified in the wild: ChatGPT's prefill works from a plain `localhost` page, and answers **without requiring an account** — so a student can get an explanation without signing up for anything. Claude and Gemini prefills are not yet confirmed; if a parameter changes, that destination degrades to an empty chat with the text already on your clipboard.
 
 ## Attribution, licenses & copyright
 

--- a/dut-dut/README.md
+++ b/dut-dut/README.md
@@ -32,13 +32,24 @@ React 19 + Vite. One class component owns all state; everything else is presenta
 - `src/components/StaffPanel.jsx` — percussion staff notation as SVG, with playhead
 - `src/components/SettingsDrawer.jsx` — tempo, metronome, swing, mutes, section management, project save/load, exports, about
 - `src/components/InsightsPanel.jsx` — the Insights cards (sidebar or bottom-strip layout), scope toggle, and the floating tooltip shown when hovering score highlight bands
-- `src/insights-engine.js` — pure rule-based music-theory analysis (`analyzeProject`) producing insight cards with score-highlight targets and reference links, plus `buildLLMPrompt` for optional LLM commentary (the "Ask Claude" button appears only where a `window.claude.complete` runtime exists, e.g. inside a Claude artifact)
+- `src/insights-engine.js` — pure rule-based music-theory analysis (`analyzeProject`) producing insight cards with score-highlight targets and reference links, plus the context envelope (`buildCadenceContext` / `renderContextMarkdown`) used by the explain-elsewhere handoff
+- `src/components/ExplainModal.jsx` + `src/handoff.js` — "Explain this pattern elsewhere": builds a portable context document and hands it to the assistant of your choice (see below)
 - `src/staff.js` — pure staff-geometry function (noteheads, stems, beams, flags, tuplets, accents, grace notes, buzz z's); shared by the on-screen SVG staff and the PNG export
 - `src/audio-engine.js` — synthesized drum voices (oscillators + filtered noise) and a variable-duration lookahead scheduler, so beats can mix 16th/triplet/8th subdivisions in one loop
 - `src/export-utils.js` — MIDI file writer, offline WAV renderer, score-PNG renderer, download helper
 - `src/constants.js` — instrument/tool definitions, project validation (`normalizeProject`)
 
-Audio and export code load on demand (dynamic `import()`), so Vite splits them into separate chunks — the initial page load doesn't include them.
+Audio, export, and insights code load on demand (dynamic `import()`), so Vite splits them into separate chunks — the initial page load doesn't include them. Anything shared with an eagerly-loaded module has to stay dependency-free or it drags those chunks back into the main bundle, which is why `downloadBlob` lives in its own `src/download.js` and `ExplainModal` receives `LEVELS` as a prop instead of importing it.
+
+## Explaining a pattern with your own assistant
+
+The Insights panel explains patterns for free, offline, with no account and no AI involved — that stays the primary teaching surface. "Explain this pattern elsewhere" is for going deeper: it builds a self-describing context document (notation legend, the pattern, per-voice subdivisions, live-take timing, and what the built-in analyzer already found) and hands it to whichever assistant you already use.
+
+**Why a handoff instead of a built-in AI button.** A Claude Pro/Max or ChatGPT Plus subscription can't be called from code — only separately-metered API credits can, and most people using this will never have an API key. Sending the text into the chat UI where you're already signed in is the only route that reaches the subscription you already pay for. It also means **the app never calls an AI itself** and makes no network requests of its own; nothing leaves your browser until you choose to send it. (The page does still load its two fonts from Google Fonts — self-hosting them would make that guarantee absolute.)
+
+Three tiers, because the one-click path is the least reliable: **copy** works with anything including a local model, **deep links** prefill Claude / ChatGPT / Gemini when the payload fits in a URL (their `?q=` parameters are undocumented and can break, so anything too long copies and opens an empty chat rather than silently truncating), and **download .md** suits Projects, NotebookLM, or emailing a band director.
+
+Guardrails, not gates: you preview the exact text before it moves, a first-run notice explains what's shared, that it spends *your* credits, and that assistants set their own minimum ages (claude.ai is 18+, most others 13+ or parental consent). Nothing is blocked — you decide.
 
 ## Attribution, licenses & copyright
 

--- a/dut-dut/src/App.jsx
+++ b/dut-dut/src/App.jsx
@@ -8,6 +8,10 @@ import BlocksPanel from './components/BlocksPanel.jsx';
 import StaffPanel from './components/StaffPanel.jsx';
 import SettingsDrawer from './components/SettingsDrawer.jsx';
 import InsightsPanel, { InsightTooltip } from './components/InsightsPanel.jsx';
+import ExplainModal from './components/ExplainModal.jsx';
+
+const HANDOFF_ACK_KEY = 'dut-dut-handoff-ack-v1';
+const EXPLAIN_LEVEL_KEY = 'dut-dut-explain-level-v1';
 
 export default class App extends Component {
   state = {
@@ -42,6 +46,9 @@ export default class App extends Component {
     llmText: '',
     llmLabel: '',
     llmLoading: false,
+    explainOpen: false,
+    explainLevel: 'new',     // see LEVELS in insights-engine
+    handoffAcked: false,     // first-run handoff disclosure dismissed
   };
 
   constructor(props) {
@@ -69,6 +76,11 @@ export default class App extends Component {
     } catch (e) { /* keep defaults */ }
     this._llmOk = typeof window !== 'undefined' && window.claude && typeof window.claude.complete === 'function';
     import('./insights-engine.js').then(m => { this._insights = m; this.forceUpdate(); }).catch(() => {});
+    try {
+      const acked = localStorage.getItem(HANDOFF_ACK_KEY) === '1';
+      const lvl = localStorage.getItem(EXPLAIN_LEVEL_KEY);
+      this.setState({ handoffAcked: acked, explainLevel: lvl || 'new' });
+    } catch (e) { /* keep defaults */ }
   }
   componentWillUnmount() {
     window.removeEventListener('mouseup', this._mouseUpHandler);
@@ -456,12 +468,33 @@ export default class App extends Component {
       rows: ALL_ROWS.map(r => ({ id: r.id, groupId: r.groupId })),
     };
   }
+  openExplain = () => this.setState({ explainOpen: true });
+  closeExplain = () => this.setState({ explainOpen: false });
+  setExplainLevel = (id) => {
+    this.setState({ explainLevel: id });
+    try { localStorage.setItem(EXPLAIN_LEVEL_KEY, id); } catch (e) { /* storage blocked */ }
+  };
+  ackHandoff = () => {
+    this.setState({ handoffAcked: true });
+    try { localStorage.setItem(HANDOFF_ACK_KEY, '1'); } catch (e) { /* storage blocked */ }
+  };
+  // The exact text the user previews and sends — nothing else leaves the app.
+  _explainText() {
+    if (!this._insights) return '';
+    try {
+      const ctx = this._insights.buildCadenceContext(this._project(), this._analysisOpts());
+      return this._insights.renderContextMarkdown(ctx, { level: this.state.explainLevel });
+    } catch (e) {
+      return '';
+    }
+  }
+
   askClaude = async () => {
     if (this.state.llmLoading || !this._llmOk || !this._insights) return;
     const label = this.state.insightScope === 'cadence' ? 'Claude on the full cadence' : 'Claude on "' + this._activeSection().name + '"';
     this.setState({ llmLoading: true });
     try {
-      const prompt = this._insights.buildLLMPrompt(this._project(), this._analysisOpts());
+      const prompt = this._insights.buildLLMPrompt(this._project(), { ...this._analysisOpts(), level: this.state.explainLevel });
       const text = await window.claude.complete(prompt);
       this.setState({ llmText: String(text || '').trim(), llmLabel: label, llmLoading: false });
     } catch (e) {
@@ -597,6 +630,8 @@ export default class App extends Component {
       askClaudeLabel: this.state.llmLoading ? 'Asking Claude…' : 'Ask Claude to explain this pattern',
       llmText: this.state.llmText,
       llmLabel: this.state.llmLabel,
+      explainAvailable: !!this._insights,
+      onExplain: this.openExplain,
     };
     const insightsPanelProps = {
       cards: insightCards,
@@ -785,6 +820,19 @@ export default class App extends Component {
             rendering={this.state.rendering}
           />
           <InsightTooltip tip={tipData} tipKeep={this.tipKeep} tipLeave={this.unhoverInsight} />
+          <ExplainModal
+            open={this.state.explainOpen}
+            onClose={this.closeExplain}
+            text={this.state.explainOpen ? this._explainText() : ''}
+            levels={(this._insights && this._insights.LEVELS) || []}
+            level={this.state.explainLevel}
+            setLevel={this.setExplainLevel}
+            scopeLabel={this.state.insightScope === 'cadence'
+              ? `The whole cadence — ${sections.length} sections`
+              : `The "${section.name}" section only`}
+            showDisclosure={!this.state.handoffAcked}
+            onDismissDisclosure={this.ackHandoff}
+          />
         </div>
       </div>
     );

--- a/dut-dut/src/App.jsx
+++ b/dut-dut/src/App.jsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import {
-  GROUPS_META, ALL_ROWS, TOOLS, STORAGE_KEY, COLORS,
-  defaultSections, makeSectionNotes, makeBeatSubs, resizeBeatArray, normalizeProject,
+  GROUPS_META, ALL_ROWS, ROW_GROUP, TOOLS, STORAGE_KEY, COLORS, TAKE_DEFAULT,
+  defaultSections, beatCount, makeSectionNotes, makeBeatSubs, makeGroupSubs, resizeBeatArray, normalizeProject,
 } from './constants.js';
 import { buildStaffShapes } from './staff.js';
 import BlocksPanel from './components/BlocksPanel.jsx';
@@ -13,18 +13,23 @@ export default class App extends Component {
   state = {
     screen: 'editor',        // 'editor' | 'preview'
     viewport: 'desktop',     // 'desktop' | 'mobile'
-    mobileTab: 'blocks',     // 'blocks' | 'staff'
+    mobileTab: 'blocks',     // 'blocks' | 'staff' | 'learn'
     settingsOpen: false,
     sections: defaultSections(),
     activeSectionId: 'intro',
-    beatSubs: null,          // { [sectionId]: number[] } — subdivisions (2/3/4) per beat
+    beatSubs: null,          // { [sectionId]: number[] } — ruler subdivisions (2/3/4) per beat
+    groupSubs: null,         // { [sectionId]: { [groupId]: number[] } } — per-part overrides, 0 = inherit
     notes: null,             // { [sectionId]: { [rowId]: number[][] } } — [beat][sub] note values
+    live: null,              // { [sectionId]: { [rowId]: number[][] } } — [beat][sub] tap metadata
     tool: 'hit',
+    perPart: false,          // show the per-part ÷ chip row
+    selectedRowId: null,     // the drum Space taps into
+    tapMode: 'quant',        // 'quant' | 'exact'
     swing: 0,
     metronome: false,
     tempo: 120,
     playing: false,
-    playheadPos: -1,
+    playBeat: -1,            // fractional beat position of the playhead
     muted: { cymbal: false, snare: false, tenor: false, bass: false },
     painting: null,          // { value } while a drag-paint is in progress
     rendering: false,        // WAV export in progress
@@ -41,15 +46,23 @@ export default class App extends Component {
 
   constructor(props) {
     super(props);
-    const notes = {}, beatSubs = {};
-    for (const s of this.state.sections) { notes[s.id] = makeSectionNotes(s); beatSubs[s.id] = makeBeatSubs(s); }
-    this.state = { ...this.state, notes, beatSubs };
+    const notes = {}, live = {}, beatSubs = {}, groupSubs = {};
+    for (const s of this.state.sections) {
+      notes[s.id] = makeSectionNotes(s);
+      live[s.id] = makeSectionNotes(s);
+      beatSubs[s.id] = makeBeatSubs(s);
+      groupSubs[s.id] = makeGroupSubs(s);
+    }
+    this.state = { ...this.state, notes, live, beatSubs, groupSubs };
+    this._marks = [];        // recent { beat, time } scheduler marks, for the visual clock
   }
 
   componentDidMount() {
     if (window.innerWidth < 820) this.setState({ viewport: 'mobile' });
     this._mouseUpHandler = () => this.cellUp();
     window.addEventListener('mouseup', this._mouseUpHandler);
+    this._keyHandler = (e) => this.onKeyDown(e);
+    window.addEventListener('keydown', this._keyHandler);
     try {
       const saved = localStorage.getItem(STORAGE_KEY);
       if (saved) this._applyProject(JSON.parse(saved));
@@ -59,8 +72,10 @@ export default class App extends Component {
   }
   componentWillUnmount() {
     window.removeEventListener('mouseup', this._mouseUpHandler);
+    window.removeEventListener('keydown', this._keyHandler);
     clearTimeout(this._saveT);
     clearTimeout(this._tipT);
+    cancelAnimationFrame(this._raf);
     this._scheduler?.stop();
   }
 
@@ -71,33 +86,29 @@ export default class App extends Component {
     }, 400);
   }
   _serializeProject() {
-    const { tempo, swing, sections, beatSubs, notes, activeSectionId } = this.state;
-    return JSON.stringify({ v: 2, app: 'dut-dut', tempo, swing, sections, beatSubs, notes, activeSectionId });
+    const { tempo, swing, sections, beatSubs, groupSubs, notes, live, activeSectionId } = this.state;
+    return JSON.stringify({ v: 3, app: 'dut-dut', tempo, swing, sections, beatSubs, groupSubs, notes, live, activeSectionId });
   }
   _project() {
-    const { tempo, swing, sections, beatSubs, notes } = this.state;
-    return { tempo, swing, sections, beatSubs, notes };
+    const { tempo, swing, sections, beatSubs, groupSubs, notes, live } = this.state;
+    return { tempo, swing, sections, beatSubs, groupSubs, notes, live };
   }
   _applyProject(p) {
     const norm = normalizeProject(p);
-    if (this.state.playing) this._scheduler?.stop();
-    this.setState({ ...norm, playing: false, playheadPos: -1 });
+    if (this.state.playing) this._stopClock();
+    this.setState({ ...norm, playing: false, playBeat: -1 });
     this._persist();
   }
 
   _activeSection() {
     return this.state.sections.find(s => s.id === this.state.activeSectionId) || this.state.sections[0];
   }
-  _subs() { return this.state.beatSubs[this._activeSection().id]; }
-  _posCount() { return this._subs().reduce((a, b) => a + b, 0); }
-  _resolvePos(pos) {
-    const subs = this._subs();
-    let acc = 0;
-    for (let b = 0; b < subs.length; b++) {
-      if (pos < acc + subs[b]) return { beat: b, sub: pos - acc, subCount: subs[b] };
-      acc += subs[b];
-    }
-    return { beat: 0, sub: 0, subCount: subs[0] || 4 };
+  // Effective subdivisions for one part: its own override where set, else the ruler.
+  _subsFor(sectionId, groupId) {
+    const master = this.state.beatSubs[sectionId];
+    const ov = (this.state.groupSubs[sectionId] || {})[groupId];
+    if (!ov) return master;
+    return master.map((m, i) => ov[i] || m);
   }
 
   async _ensureAudio() {
@@ -109,54 +120,137 @@ export default class App extends Component {
     if (!this._scheduler) {
       this._scheduler = new mod.VarScheduler({
         audioContext: this._audioCtx,
-        getPositionCount: () => this._posCount(),
-        getDuration: (pos) => (60 / this.state.tempo) / this._resolvePos(pos).subCount,
-        onScheduleStep: (pos, time) => this._onStep(mod, pos, time),
+        getPositionCount: () => beatCount(this._activeSection()),
+        getDuration: () => 60 / this.state.tempo,
+        onScheduleStep: (beat, time) => this._onStep(mod, beat, time),
       });
     }
     return mod;
   }
 
-  _onStep(mod, pos, time) {
+  // One scheduler step is one beat: every part places its own subdivisions inside it.
+  _onStep(mod, beat, time) {
     const section = this._activeSection();
-    const notes = this.state.notes[section.id];
-    const { beat, sub, subCount } = this._resolvePos(pos);
-    const dur = (60 / this.state.tempo) / subCount;
-    let t = time;
-    if (subCount % 2 === 0 && sub % 2 === 1) t += dur * (this.state.swing / 100) * 0.5;
-    if (this.state.metronome && sub === 0) {
-      mod.playMetronome(this._audioCtx, t, this._audioCtx.destination, beat % 4 === 0);
-    }
-    const dest = this._audioCtx.destination;
+    const notesFor = this.state.notes[section.id];
+    const liveFor = this.state.live[section.id];
+    const beatDur = 60 / this.state.tempo;
+    const ctx = this._audioCtx, dest = ctx.destination;
+    this._marks.push({ beat, time });
+    if (this._marks.length > 32) this._marks.shift();
+    if (this.state.metronome) mod.playMetronome(ctx, time, dest, beat % 4 === 0);
     for (const row of ALL_ROWS) {
       if (this.state.muted[row.groupId]) continue;
-      const v = notes[row.id][beat][sub];
-      if (!v) continue;
+      const sc = this._subsFor(section.id, row.groupId)[beat];
+      const dur = beatDur / sc;
+      const arr = notesFor[row.id][beat] || [];
+      const larr = (liveFor && liveFor[row.id] && liveFor[row.id][beat]) || [];
       const play = this._voicePlayers[row.id];
-      if (v === 1) play(this._audioCtx, t, dest, 1);
-      else if (v === 2) play(this._audioCtx, t, dest, 2);
-      else if (v === 3) { play(this._audioCtx, t - 0.028, dest, 0); play(this._audioCtx, t, dest, 1); }
-      else if (v === 4) { play(this._audioCtx, t, dest, 1); play(this._audioCtx, t + dur / 2, dest, 1); }
-      else if (v === 5) { for (let i = 0; i < 4; i++) play(this._audioCtx, t + i * dur / 4, dest, i === 0 ? 1 : 0); }
+      for (let s = 0; s < sc; s++) {
+        const v = arr[s];
+        if (!v) continue;
+        let t = time + s * dur;
+        const m = larr[s] || 0;
+        if (m >= 2) t += (m - 2) * dur;
+        else if (sc % 2 === 0 && s % 2 === 1) t += dur * (this.state.swing / 100) * 0.5;
+        if (v === 1) play(ctx, t, dest, 1);
+        else if (v === 2) play(ctx, t, dest, 2);
+        else if (v === 3) { play(ctx, Math.max(0.001, t - 0.028), dest, 0); play(ctx, t, dest, 1); }
+        else if (v === 4) { play(ctx, t, dest, 1); play(ctx, t + dur / 2, dest, 1); }
+        else if (v === 5) { for (let i = 0; i < 4; i++) play(ctx, t + i * dur / 4, dest, i === 0 ? 1 : 0); }
+      }
     }
-    requestAnimationFrame(() => this.setState({ playheadPos: pos }));
+  }
+
+  _markAt(now) {
+    let best = null;
+    for (const m of this._marks) if (m.time <= now && (!best || m.time > best.time)) best = m;
+    return best;
+  }
+  // Where the music actually is right now, in fractional beats.
+  _beatPos(now) {
+    const m = this._markAt(now);
+    if (!m) return -1;
+    const beatDur = 60 / this.state.tempo;
+    const beats = beatCount(this._activeSection());
+    const pos = m.beat + Math.max(0, Math.min(1.2, (now - m.time) / beatDur));
+    return ((pos % beats) + beats) % beats;
+  }
+  _startClock() {
+    cancelAnimationFrame(this._raf);
+    const loop = () => {
+      if (!this.state.playing) return;
+      this._raf = requestAnimationFrame(loop);
+      const now = performance.now();
+      if (now - (this._lastPaint || 0) < 55) return;
+      this._lastPaint = now;
+      const pos = this._beatPos(this._audioCtx.currentTime);
+      if (pos >= 0) this.setState({ playBeat: pos });
+    };
+    this._raf = requestAnimationFrame(loop);
+  }
+  _stopClock() {
+    cancelAnimationFrame(this._raf);
+    this._scheduler?.stop();
+    this._marks = [];
   }
 
   togglePlay = async () => {
     if (this.state.playing) {
-      this._scheduler?.stop();
-      this.setState({ playing: false, playheadPos: -1 });
+      this._stopClock();
+      this.setState({ playing: false, playBeat: -1 });
       return;
     }
     await this._ensureAudio();
+    this._marks = [];
     this._scheduler.start();
-    this.setState({ playing: true });
+    this.setState({ playing: true }, () => this._startClock());
   };
+
+  // Space is a drumstick, never a transport control: it only writes notes.
+  onKeyDown = (e) => {
+    if (e.code !== 'Space' || e.metaKey || e.ctrlKey || e.altKey) return;
+    const t = e.target;
+    if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+    e.preventDefault();
+    if (e.repeat) return;
+    if (this.state.playing && this.state.selectedRowId) this._recordTap();
+  };
+
+  // Space during playback writes into the selected drum — either at the moment it was
+  // played (exact) or pulled to the nearest subdivision (auto-rhythm).
+  _recordTap() {
+    if (!this._audioCtx) return;
+    const rowId = this.state.selectedRowId;
+    const section = this._activeSection();
+    const beats = beatCount(section);
+    const now = this._audioCtx.currentTime - (this._audioCtx.outputLatency || this._audioCtx.baseLatency || 0);
+    const pos = this._beatPos(now);
+    if (pos < 0) return;
+    const subs = this._subsFor(section.id, ROW_GROUP[rowId]);
+    let b = Math.floor(pos);
+    const frac = pos - b;
+    const sc = subs[b] || 4;
+    const toolV = (TOOLS.find(tl => tl.id === this.state.tool) || {}).v || 1;
+    const value = toolV || 1;
+    let sub, meta;
+    if (this.state.tapMode === 'quant') {
+      let k = Math.round(frac * sc);
+      if (k >= sc) { b = (b + 1) % beats; k = 0; }
+      sub = k; meta = 1;
+    } else {
+      const k = Math.max(0, Math.min(sc - 1, Math.floor(frac * sc)));
+      sub = k; meta = 2 + Math.max(0, Math.min(0.995, frac * sc - k));
+    }
+    this._writeCell(rowId, b, sub, value, meta);
+    if (this._voicePlayers && !this.state.muted[ROW_GROUP[rowId]]) {
+      this._voicePlayers[rowId](this._audioCtx, this._audioCtx.currentTime + 0.005, this._audioCtx.destination, value === 2 ? 2 : 1);
+    }
+  }
 
   setTempo = (v) => { this.setState({ tempo: Math.max(40, Math.min(240, Math.round(Number(v) || 120))) }); this._persist(); };
 
   selectSection = (id) => {
-    if (this.state.playing) { this._scheduler?.stop(); this.setState({ playing: false, playheadPos: -1 }); }
+    if (this.state.playing) { this._stopClock(); this.setState({ playing: false, playBeat: -1 }); }
     this.setState({ activeSectionId: id });
     this._persist();
   };
@@ -166,7 +260,9 @@ export default class App extends Component {
     this.setState({
       sections: [...this.state.sections, section],
       notes: { ...this.state.notes, [id]: makeSectionNotes(section) },
+      live: { ...this.state.live, [id]: makeSectionNotes(section) },
       beatSubs: { ...this.state.beatSubs, [id]: makeBeatSubs(section) },
+      groupSubs: { ...this.state.groupSubs, [id]: makeGroupSubs(section) },
       activeSectionId: id,
     });
     this._persist();
@@ -177,54 +273,119 @@ export default class App extends Component {
     const sections = this.state.sections.map(s => s.id === id ? { ...s, measures } : s);
     const count = measures * 4;
     const subs = resizeBeatArray(this.state.beatSubs[id], count, () => 4);
-    const rows = {};
-    for (const row of ALL_ROWS) rows[row.id] = resizeBeatArray(this.state.notes[id][row.id], count, (i) => new Array(subs[i]).fill(0));
-    this.setState({ sections, beatSubs: { ...this.state.beatSubs, [id]: subs }, notes: { ...this.state.notes, [id]: rows } });
+    const gs = {};
+    for (const gm of GROUPS_META) gs[gm.id] = resizeBeatArray((this.state.groupSubs[id] || {})[gm.id] || [], count, () => 0);
+    const rows = {}, lrows = {};
+    for (const row of ALL_ROWS) {
+      const sizeAt = (i) => gs[row.groupId][i] || subs[i];
+      rows[row.id] = resizeBeatArray(this.state.notes[id][row.id], count, (i) => new Array(sizeAt(i)).fill(0));
+      lrows[row.id] = resizeBeatArray(this.state.live[id][row.id], count, (i) => new Array(sizeAt(i)).fill(0));
+    }
+    this.setState({
+      sections,
+      beatSubs: { ...this.state.beatSubs, [id]: subs },
+      groupSubs: { ...this.state.groupSubs, [id]: gs },
+      notes: { ...this.state.notes, [id]: rows },
+      live: { ...this.state.live, [id]: lrows },
+    });
     this._persist();
   };
   deleteSection = (id) => {
     if (this.state.sections.length <= 1) return;
     const sections = this.state.sections.filter(s => s.id !== id);
     const notes = { ...this.state.notes }; delete notes[id];
+    const live = { ...this.state.live }; delete live[id];
     const beatSubs = { ...this.state.beatSubs }; delete beatSubs[id];
+    const groupSubs = { ...this.state.groupSubs }; delete groupSubs[id];
     const activeSectionId = this.state.activeSectionId === id ? sections[0].id : this.state.activeSectionId;
-    this.setState({ sections, notes, beatSubs, activeSectionId });
+    this.setState({ sections, notes, live, beatSubs, groupSubs, activeSectionId });
     this._persist();
   };
 
-  cycleBeatSub = (beatIdx) => {
-    const section = this._activeSection();
-    const subs = this.state.beatSubs[section.id].slice();
-    const next = subs[beatIdx] === 4 ? 3 : subs[beatIdx] === 3 ? 2 : 4;
-    subs[beatIdx] = next;
-    const rows = {};
+  // Any subdivision change re-buckets every row to its part's new cell count.
+  _applySubs(master, gsubs) {
+    const sid = this._activeSection().id;
+    const beats = master.length;
+    const rows = {}, lrows = {};
     for (const row of ALL_ROWS) {
-      const beats = this.state.notes[section.id][row.id].slice();
-      const old = beats[beatIdx];
-      const na = new Array(next).fill(0);
-      for (let i = 0; i < Math.min(next, old.length); i++) na[i] = old[i];
-      beats[beatIdx] = na;
-      rows[row.id] = beats;
+      const oldN = this.state.notes[sid][row.id], oldL = this.state.live[sid][row.id];
+      const nb = [], nl = [];
+      for (let b = 0; b < beats; b++) {
+        const sc = (gsubs[row.groupId] && gsubs[row.groupId][b]) || master[b];
+        const on = oldN[b] || [], ol = (oldL && oldL[b]) || [];
+        const na = new Array(sc).fill(0), la = new Array(sc).fill(0);
+        for (let i = 0; i < Math.min(sc, on.length); i++) { na[i] = on[i]; la[i] = ol[i] || 0; }
+        nb.push(na); nl.push(la);
+      }
+      rows[row.id] = nb; lrows[row.id] = nl;
     }
     this.setState({
-      beatSubs: { ...this.state.beatSubs, [section.id]: subs },
-      notes: { ...this.state.notes, [section.id]: rows },
+      beatSubs: { ...this.state.beatSubs, [sid]: master },
+      groupSubs: { ...this.state.groupSubs, [sid]: gsubs },
+      notes: { ...this.state.notes, [sid]: rows },
+      live: { ...this.state.live, [sid]: lrows },
     });
     this._persist();
+  }
+  cycleBeatSub = (beatIdx) => {
+    const sid = this._activeSection().id;
+    const master = this.state.beatSubs[sid].slice();
+    master[beatIdx] = master[beatIdx] === 4 ? 3 : master[beatIdx] === 3 ? 2 : 4;
+    this._applySubs(master, this.state.groupSubs[sid]);
   };
+  cycleGroupBeatSub = (groupId, beatIdx) => {
+    const sid = this._activeSection().id;
+    const gsubs = { ...this.state.groupSubs[sid] };
+    const arr = (gsubs[groupId] || []).slice();
+    const cur = arr[beatIdx] || 0;
+    arr[beatIdx] = cur === 0 ? 4 : cur === 4 ? 3 : cur === 3 ? 2 : 0;
+    gsubs[groupId] = arr;
+    this._applySubs(this.state.beatSubs[sid], gsubs);
+  };
+  resetGroupSubs = (groupId) => {
+    const sid = this._activeSection().id;
+    const gsubs = { ...this.state.groupSubs[sid] };
+    gsubs[groupId] = new Array(this.state.beatSubs[sid].length).fill(0);
+    this._applySubs(this.state.beatSubs[sid], gsubs);
+  };
+  resetAllSubs = () => {
+    const sid = this._activeSection().id;
+    const gsubs = {};
+    for (const gm of GROUPS_META) gsubs[gm.id] = new Array(this.state.beatSubs[sid].length).fill(0);
+    this._applySubs(this.state.beatSubs[sid], gsubs);
+  };
+  togglePerPart = () => this.setState({ perPart: !this.state.perPart });
 
   setSwing = (v) => { this.setState({ swing: Number(v) }); this._persist(); };
   toggleMetronome = () => this.setState({ metronome: !this.state.metronome });
   toggleMute = (groupId) => this.setState({ muted: { ...this.state.muted, [groupId]: !this.state.muted[groupId] } });
   setTool = (id) => this.setState({ tool: id });
+  selectRow = (rowId) => {
+    this._lastRow = { ...(this._lastRow || {}), [ROW_GROUP[rowId]]: rowId };
+    this.setState({ selectedRowId: this.state.selectedRowId === rowId ? null : rowId });
+  };
+  armGroup = (groupId) => {
+    if (ROW_GROUP[this.state.selectedRowId] === groupId) { this.setState({ selectedRowId: null }); return; }
+    const gm = GROUPS_META.find(g => g.id === groupId);
+    const rowId = ((this._lastRow || {})[groupId]) || gm.rowDefs[0].id;
+    this.setState({ selectedRowId: rowId });
+  };
+  setTapMode = (m) => this.setState({ tapMode: m });
 
-  _paintCell(rowId, beat, sub, value) {
-    const section = this._activeSection();
-    const beats = this.state.notes[section.id][rowId].slice();
+  _writeCell(rowId, beat, sub, value, meta) {
+    const sid = this._activeSection().id;
+    const beats = this.state.notes[sid][rowId].slice();
     const na = beats[beat].slice();
     na[sub] = value;
     beats[beat] = na;
-    this.setState({ notes: { ...this.state.notes, [section.id]: { ...this.state.notes[section.id], [rowId]: beats } } });
+    const lbeats = this.state.live[sid][rowId].slice();
+    const la = (lbeats[beat] || []).slice();
+    la[sub] = value ? (meta || 0) : 0;
+    lbeats[beat] = la;
+    this.setState({
+      notes: { ...this.state.notes, [sid]: { ...this.state.notes[sid], [rowId]: beats } },
+      live: { ...this.state.live, [sid]: { ...this.state.live[sid], [rowId]: lbeats } },
+    });
     this._persist();
   }
   cellDown = (rowId, beat, sub) => {
@@ -232,20 +393,34 @@ export default class App extends Component {
     const cur = this.state.notes[section.id][rowId][beat][sub];
     const toolV = TOOLS.find(tl => tl.id === this.state.tool).v;
     const value = (toolV !== 0 && cur === toolV) ? 0 : toolV;
-    this._paintCell(rowId, beat, sub, value);
+    this._writeCell(rowId, beat, sub, value, 0);
     this.setState({ painting: { value } });
   };
   cellEnter = (rowId, beat, sub) => {
     if (!this.state.painting) return;
-    this._paintCell(rowId, beat, sub, this.state.painting.value);
+    this._writeCell(rowId, beat, sub, this.state.painting.value, 0);
   };
   cellUp = () => this.state.painting && this.setState({ painting: null });
   clearSection = () => {
-    const section = this._activeSection();
-    const subs = this.state.beatSubs[section.id];
-    const rows = {};
-    for (const row of ALL_ROWS) rows[row.id] = subs.map(sc => new Array(sc).fill(0));
-    this.setState({ notes: { ...this.state.notes, [section.id]: rows } });
+    const sid = this._activeSection().id;
+    const rows = {}, lrows = {};
+    for (const row of ALL_ROWS) {
+      const sizes = this._subsFor(sid, row.groupId);
+      rows[row.id] = sizes.map(sc => new Array(sc).fill(0));
+      lrows[row.id] = sizes.map(sc => new Array(sc).fill(0));
+    }
+    this.setState({ notes: { ...this.state.notes, [sid]: rows }, live: { ...this.state.live, [sid]: lrows } });
+    this._persist();
+  };
+  clearTake = () => {
+    const sid = this._activeSection().id;
+    const rows = {}, lrows = {};
+    for (const row of ALL_ROWS) {
+      const nb = this.state.notes[sid][row.id], lb = this.state.live[sid][row.id];
+      rows[row.id] = nb.map((cell, b) => cell.map((v, s) => ((lb[b] && lb[b][s]) ? 0 : v)));
+      lrows[row.id] = lb.map(cell => cell.map(() => 0));
+    }
+    this.setState({ notes: { ...this.state.notes, [sid]: rows }, live: { ...this.state.live, [sid]: lrows } });
     this._persist();
   };
 
@@ -286,7 +461,7 @@ export default class App extends Component {
     const label = this.state.insightScope === 'cadence' ? 'Claude on the full cadence' : 'Claude on "' + this._activeSection().name + '"';
     this.setState({ llmLoading: true });
     try {
-      const prompt = this._insights.buildLLMPrompt({ sections: this.state.sections, beatSubs: this.state.beatSubs, notes: this.state.notes, tempo: this.state.tempo, swing: this.state.swing }, this._analysisOpts());
+      const prompt = this._insights.buildLLMPrompt(this._project(), this._analysisOpts());
       const text = await window.claude.complete(prompt);
       this.setState({ llmText: String(text || '').trim(), llmLabel: label, llmLoading: false });
     } catch (e) {
@@ -328,26 +503,39 @@ export default class App extends Component {
   onExportPng = async () => {
     const u = await import('./export-utils.js');
     const beatW = 96, leftPad = 60;
+    const opts = { unison: this.props.unisonNotation ?? true };
     const render = this.state.sections.map(sec => ({
       name: sec.name,
       groups: GROUPS_META.map(g => ({
         name: g.name, color: g.color,
-        shapes: buildStaffShapes(g, g.rowDefs.map(rd => this.state.notes[sec.id][rd.id]), this.state.beatSubs[sec.id], sec.measures, beatW, leftPad),
+        shapes: buildStaffShapes(
+          g,
+          g.rowDefs.map(rd => this.state.notes[sec.id][rd.id]),
+          g.rowDefs.map(rd => this.state.live[sec.id][rd.id]),
+          this._subsFor(sec.id, g.id), sec.measures, beatW, leftPad, opts,
+        ),
       })),
     }));
     await u.renderScorePng(render, { title: 'dut dut — cadence', tempo: this.state.tempo });
   };
 
   render() {
-    const { screen, viewport, mobileTab, settingsOpen, sections, tempo, playing, playheadPos } = this.state;
+    const { screen, viewport, mobileTab, settingsOpen, sections, tempo, playing, playBeat } = this.state;
     const section = this._activeSection();
-    const subs = this.state.beatSubs[section.id];
     const isMobile = viewport === 'mobile';
     const isEditor = screen === 'editor';
     const isPreview = screen === 'preview';
     const { accent, onAccent, text, mutedText, border } = COLORS;
+    const takeColor = this.props.takeColor || TAKE_DEFAULT;
 
     const tabStyle = (active) => ({ background: active ? accent : 'transparent', color: active ? onAccent : mutedText });
+
+    const subsByGroup = {};
+    for (const g of GROUPS_META) subsByGroup[g.id] = this._subsFor(section.id, g.id);
+    const overrides = this.state.groupSubs[section.id] || {};
+    const anyOverride = GROUPS_META.some(g => (overrides[g.id] || []).some(v => v));
+    const selRow = ALL_ROWS.find(r => r.id === this.state.selectedRowId) || null;
+    const hasTake = ALL_ROWS.some(r => (this.state.live[section.id][r.id] || []).some(cell => cell.some(m => m)));
 
     // ---- Insights ----
     const insightsLayout = ['sidebar', 'bottom', 'inline'].includes(this.props.insightsLayout) ? this.props.insightsLayout : 'sidebar';
@@ -355,10 +543,7 @@ export default class App extends Component {
     let insights = [];
     if (this._insights) {
       try {
-        insights = this._insights.analyzeProject(
-          { sections, beatSubs: this.state.beatSubs, notes: this.state.notes, tempo, swing: this.state.swing },
-          this._analysisOpts(),
-        );
+        insights = this._insights.analyzeProject(this._project(), this._analysisOpts());
       } catch (e) { insights = []; }
     }
     const focusId = this.state.hoverInsightId || this.state.pinnedInsightId;
@@ -487,17 +672,33 @@ export default class App extends Component {
                 }}
                 isMobile={isMobile}
                 section={section}
-                subs={subs}
+                masterSubs={this.state.beatSubs[section.id]}
+                subsByGroup={subsByGroup}
+                overrides={overrides}
                 sectionNotes={this.state.notes[section.id]}
+                sectionLive={this.state.live[section.id]}
                 tool={this.state.tool}
                 setTool={this.setTool}
                 tempo={tempo}
                 muted={this.state.muted}
                 toggleMute={this.toggleMute}
                 cycleBeatSub={this.cycleBeatSub}
+                cycleGroupBeatSub={this.cycleGroupBeatSub}
+                resetGroupSubs={this.resetGroupSubs}
+                perPart={this.state.perPart}
+                togglePerPart={this.togglePerPart}
+                selectedRowId={this.state.selectedRowId}
+                selectRow={this.selectRow}
+                armGroup={this.armGroup}
+                selRow={selRow}
+                tapMode={this.state.tapMode}
+                setTapMode={this.setTapMode}
+                hasTake={hasTake}
+                clearTake={this.clearTake}
+                takeColor={takeColor}
                 cellDown={this.cellDown}
                 cellEnter={this.cellEnter}
-                playheadPos={playheadPos}
+                playBeat={playBeat}
                 tintByGroup={focusBeatByGroup}
                 focusColor={focusInsight ? focusInsight.color : null}
               />
@@ -509,13 +710,16 @@ export default class App extends Component {
                 isMobile={isMobile}
                 isPreview={isPreview}
                 section={section}
-                subs={subs}
+                subsByGroup={subsByGroup}
                 sectionNotes={this.state.notes[section.id]}
+                sectionLive={this.state.live[section.id]}
                 tempo={tempo}
                 playing={playing}
                 onTogglePlay={this.togglePlay}
-                playheadPos={playheadPos}
-                resolvePos={(pos) => this._resolvePos(pos)}
+                playBeat={playBeat}
+                unison={this.props.unisonNotation ?? true}
+                takeColor={takeColor}
+                hasTake={hasTake}
                 insights={insights}
                 showBands={isEditor && showHighlights}
                 focusId={focusId}
@@ -553,6 +757,16 @@ export default class App extends Component {
             toggleMetronome={this.toggleMetronome}
             setViewport={this.setViewport}
             clearSection={this.clearSection}
+            selRow={selRow}
+            tapMode={this.state.tapMode}
+            setTapMode={this.setTapMode}
+            hasTake={hasTake}
+            clearTake={this.clearTake}
+            takeColor={takeColor}
+            perPart={this.state.perPart}
+            togglePerPart={this.togglePerPart}
+            anyOverride={anyOverride}
+            resetAllSubs={this.resetAllSubs}
             swing={this.state.swing}
             setSwing={this.setSwing}
             muted={this.state.muted}

--- a/dut-dut/src/components/BlocksPanel.jsx
+++ b/dut-dut/src/components/BlocksPanel.jsx
@@ -1,19 +1,22 @@
-import { GROUPS_META, TOOLS, COLORS } from '../constants.js';
+import { GROUPS_META, ALL_ROWS, ROW_GROUP, TOOLS, COLORS } from '../constants.js';
+
+const subLabel = (sc) => (sc === 4 ? '16' : sc === 3 ? '3' : '8');
 
 export default function BlocksPanel({
-  style, isMobile, section, subs, sectionNotes, tool, setTool, tempo,
-  muted, toggleMute, cycleBeatSub, cellDown, cellEnter, playheadPos,
+  style, isMobile, section, masterSubs, subsByGroup, overrides, sectionNotes, sectionLive,
+  tool, setTool, tempo, muted, toggleMute,
+  cycleBeatSub, cycleGroupBeatSub, resetGroupSubs, perPart, togglePerPart,
+  selectedRowId, selectRow, armGroup, selRow, tapMode, setTapMode,
+  hasTake, clearTake, takeColor, cellDown, cellEnter, playBeat,
   tintByGroup = null, focusColor = null,
 }) {
   const beats = section.measures * 4;
   const beatW = isMobile ? 112 : 128;
   const cellH = isMobile ? 40 : 34;
   const { accent, onAccent, text, mutedText, ink, border } = COLORS;
+  const tapExactOn = tapMode === 'exact';
 
-  // Flat position index of each beat's first cell, for playhead matching.
-  const flatBase = [];
-  let acc = 0;
-  for (let b = 0; b < beats; b++) { flatBase.push(acc); acc += subs[b]; }
+  const modeStyle = (active) => ({ background: active ? takeColor : 'transparent', color: active ? onAccent : mutedText });
 
   return (
     <div className="blocks-panel" style={style}>
@@ -41,20 +44,55 @@ export default function BlocksPanel({
           );
         })}
       </div>
-      <div className="hint-text">Click / drag paints the tool · click a beat number for 16th → triplet → 8th</div>
+
+      <div className="hint-row">
+        <span className="hint-text">Click / drag paints · beat number cycles 16th → triplet → 8th · ÷ splits it per part</span>
+        <div className="hint-right">
+          <span
+            className="tap-target-pill"
+            style={{
+              background: selRow ? takeColor : 'transparent',
+              color: selRow ? onAccent : mutedText,
+              borderColor: selRow ? takeColor : border,
+            }}
+          >
+            {selRow ? `Space → ${selRow.label}` : 'Space → pick a drum'}
+          </span>
+          {hasTake && (
+            <div className="take-legend-row">
+              <span className="take-legend"><span className="take-dot" style={{ background: takeColor }} />tapped in</span>
+              <button className="clear-take-btn" onClick={clearTake}>Clear taps</button>
+            </div>
+          )}
+        </div>
+      </div>
 
       <div className="blocks-scroll">
         <div className="blocks-inner">
           <div className="ruler-row">
-            <div className="ruler-corner" />
+            <div className="ruler-corner">
+              <button
+                className="perpart-btn"
+                title="Per-part subdivisions — give each drum family its own 16th / triplet / 8th on any beat"
+                onClick={togglePerPart}
+                style={{
+                  background: perPart ? accent : 'oklch(94% 0.01 80)',
+                  color: perPart ? onAccent : mutedText,
+                  borderColor: perPart ? accent : border,
+                }}
+              >
+                ÷
+              </button>
+            </div>
             {Array.from({ length: beats }, (_, b) => {
-              const sc = subs[b];
+              const sc = masterSubs[b];
               const isMeasureStart = b % 4 === 0;
+              const mixed = GROUPS_META.some(g => (overrides[g.id] || [])[b]);
               return (
                 <button
                   key={b}
                   className="ruler-btn"
-                  title="Cycle subdivision: 16th → triplet → 8th"
+                  title="Cycle subdivision for every part: 16th → triplet → 8th"
                   onClick={() => cycleBeatSub(b)}
                   style={{
                     width: beatW,
@@ -68,82 +106,176 @@ export default function BlocksPanel({
                     style={{
                       color: sc === 3 ? onAccent : mutedText,
                       background: sc === 3 ? accent : 'oklch(92% 0.01 80)',
+                      border: `1px ${mixed ? 'dashed' : 'solid'} ${mixed ? 'oklch(50% 0.02 260)' : 'transparent'}`,
                     }}
                   >
-                    {sc === 4 ? '16' : sc === 3 ? '3' : '8'}
+                    {subLabel(sc)}
                   </span>
                 </button>
               );
             })}
           </div>
 
-          {GROUPS_META.map(g => (
-            <div key={g.id}>
-              <div className="group-header">
-                <div className="group-dot" style={{ background: g.color }} />
-                <div className="group-name">{g.name}</div>
-                <button
-                  className="mute-btn"
-                  onClick={() => toggleMute(g.id)}
-                  style={{ background: muted[g.id] ? 'oklch(72% 0.12 25)' : 'transparent', color: muted[g.id] ? text : mutedText }}
-                >
-                  {muted[g.id] ? 'Muted' : 'Mute'}
-                </button>
-              </div>
-              {g.rowDefs.map(rowDef => (
-                <div key={rowDef.id} className="row-line">
-                  <div className="row-label">{rowDef.label}</div>
-                  <div className="row-cells">
-                    {Array.from({ length: beats }, (_, b) => {
-                      const sc = subs[b];
-                      const w = beatW / sc;
-                      return Array.from({ length: sc }, (_, s) => {
-                        const v = sectionNotes[rowDef.id][b][s];
-                        const isMeasureStart = b % 4 === 0 && s === 0;
-                        const baseBg = isMeasureStart ? 'oklch(91% 0.012 80)' : s === 0 ? 'oklch(93% 0.01 80)' : 'oklch(96% 0.007 80)';
-                        const hl = tintByGroup && tintByGroup[g.id] && tintByGroup[g.id].has(b);
-                        return (
-                          <div
-                            key={`${b}-${s}`}
-                            className="cell"
-                            onMouseDown={() => cellDown(rowDef.id, b, s)}
-                            onMouseEnter={() => cellEnter(rowDef.id, b, s)}
-                            style={{
-                              width: w,
-                              height: cellH,
-                              background: hl ? `color-mix(in oklch, ${baseBg} 55%, ${focusColor})` : baseBg,
-                            }}
-                          >
-                            {v === 3 && <div className="grace-dot" style={{ background: g.color }} />}
-                            {(v === 1 || v === 2 || v === 3 || v === 5) && (
+          {GROUPS_META.map(g => {
+            const gsubs = subsByGroup[g.id];
+            const ov = overrides[g.id] || [];
+            const armed = ROW_GROUP[selectedRowId] === g.id;
+            const armedRow = armed ? ALL_ROWS.find(r => r.id === selectedRowId) : null;
+            return (
+              <div key={g.id}>
+                <div className="group-header">
+                  <div className="group-dot" style={{ background: g.color }} />
+                  <div className="group-name">{g.name}</div>
+                  <button
+                    className="mute-btn"
+                    onClick={() => toggleMute(g.id)}
+                    style={{ background: muted[g.id] ? 'oklch(72% 0.12 25)' : 'transparent', color: muted[g.id] ? text : mutedText }}
+                  >
+                    {muted[g.id] ? 'Muted' : 'Mute'}
+                  </button>
+                  <button
+                    className="arm-btn"
+                    title="Play along on this part — hit Play, then tap Space in time and the notes land here"
+                    onClick={() => armGroup(g.id)}
+                    style={{
+                      background: armedRow ? takeColor : 'transparent',
+                      color: armedRow ? onAccent : mutedText,
+                      borderColor: armedRow ? takeColor : border,
+                    }}
+                  >
+                    {armedRow ? `Tap: ${armedRow.label}` : 'Tap in'}
+                  </button>
+                  {armed && (
+                    <div className="tap-mode-track">
+                      <button title="Keep the exact moment you tapped" onClick={() => setTapMode('exact')} style={modeStyle(tapExactOn)}>Exact</button>
+                      <button title="Pull each tap to the nearest subdivision" onClick={() => setTapMode('quant')} style={modeStyle(!tapExactOn)}>Auto-rhythm</button>
+                    </div>
+                  )}
+                  {ov.some(v => v) && (
+                    <button
+                      className="own-subs-btn"
+                      title="Reset this part to the measure subdivision"
+                      onClick={() => resetGroupSubs(g.id)}
+                      style={{ borderColor: g.color, color: g.color }}
+                    >
+                      own ÷ ×
+                    </button>
+                  )}
+                </div>
+
+                <div className="subchip-row" style={{ display: perPart ? 'flex' : 'none' }}>
+                  <div className="subchip-label">÷</div>
+                  {Array.from({ length: beats }, (_, b) => {
+                    const own = ov[b] || 0;
+                    const sc = own || masterSubs[b];
+                    const isMeasureStart = b % 4 === 0;
+                    return (
+                      <button
+                        key={b}
+                        className="subchip-btn"
+                        title="This part only, this beat: inherit → 16th → triplet → 8th"
+                        onClick={() => cycleGroupBeatSub(g.id, b)}
+                        style={{
+                          width: beatW,
+                          background: isMeasureStart ? 'oklch(96% 0.008 80)' : 'oklch(98% 0.006 80)',
+                          borderLeft: isMeasureStart ? '2px solid oklch(88% 0.012 80)' : '1px solid oklch(93% 0.008 80)',
+                        }}
+                      >
+                        <span
+                          className="subchip-pill"
+                          style={{
+                            color: own ? onAccent : 'oklch(60% 0.02 260)',
+                            background: own ? g.color : 'transparent',
+                            border: `1px ${own ? 'solid' : 'dashed'} ${own ? g.color : 'oklch(86% 0.012 80)'}`,
+                          }}
+                        >
+                          {subLabel(sc)}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {g.rowDefs.map(rowDef => {
+                  const selected = selectedRowId === rowDef.id;
+                  return (
+                    <div key={rowDef.id} className="row-line">
+                      <button
+                        className="row-label"
+                        title="Select this drum as the play-along target (Space taps notes in)"
+                        onClick={() => selectRow(rowDef.id)}
+                        style={{
+                          background: selected ? takeColor : 'oklch(98% 0.006 80)',
+                          color: selected ? onAccent : mutedText,
+                          fontWeight: selected ? 700 : 500,
+                        }}
+                      >
+                        {rowDef.label}
+                      </button>
+                      <div className="row-cells">
+                        {Array.from({ length: beats }, (_, b) => {
+                          const sc = gsubs[b];
+                          const w = beatW / sc;
+                          return Array.from({ length: sc }, (_, s) => {
+                            const v = sectionNotes[rowDef.id][b][s];
+                            const m = (sectionLive[rowDef.id][b] && sectionLive[rowDef.id][b][s]) || 0;
+                            const liveKind = m === 0 ? 0 : m === 1 ? 1 : 2;
+                            const shift = liveKind === 2 ? Math.round(Math.min(m - 2, 0.85) * w) : 0;
+                            const isMeasureStart = b % 4 === 0 && s === 0;
+                            const baseBg = isMeasureStart ? 'oklch(91% 0.012 80)' : s === 0 ? 'oklch(93% 0.01 80)' : 'oklch(96% 0.007 80)';
+                            const hl = tintByGroup && tintByGroup[g.id] && tintByGroup[g.id].has(b);
+                            const dotColor = liveKind ? takeColor : g.color;
+                            const isPlayhead = playBeat >= 0 && playBeat >= b + s / sc && playBeat < b + (s + 1) / sc;
+                            return (
                               <div
-                                className="note-dot"
+                                key={`${b}-${s}`}
+                                className="cell"
+                                onMouseDown={() => cellDown(rowDef.id, b, s)}
+                                onMouseEnter={() => cellEnter(rowDef.id, b, s)}
                                 style={{
-                                  width: v === 2 ? 17 : v === 5 ? 16 : 13,
-                                  height: v === 2 ? 17 : v === 5 ? 16 : 13,
-                                  background: g.color,
-                                  border: v === 2 ? `2px solid ${ink}` : 'none',
+                                  width: w,
+                                  height: cellH,
+                                  background: hl ? `color-mix(in oklch, ${baseBg} 55%, ${focusColor})` : baseBg,
+                                  zIndex: liveKind === 2 ? 1 : 0,
                                 }}
                               >
-                                {v === 5 && <span className="dot-z">z</span>}
+                                {liveKind === 2 && shift > 3 && (
+                                  <div className="dev-line" style={{ width: shift, background: takeColor }} />
+                                )}
+                                {v === 3 && <div className="grace-dot" style={{ background: dotColor }} />}
+                                {(v === 1 || v === 2 || v === 3 || v === 5) && (
+                                  <div
+                                    className="note-dot"
+                                    style={{
+                                      width: v === 2 ? 17 : v === 5 ? 16 : 13,
+                                      height: v === 2 ? 17 : v === 5 ? 16 : 13,
+                                      background: dotColor,
+                                      border: v === 2 ? `2px solid ${ink}` : 'none',
+                                      transform: `translateX(${shift}px)`,
+                                    }}
+                                  >
+                                    {v === 5 && <span className="dot-z">z</span>}
+                                  </div>
+                                )}
+                                {v === 4 && (
+                                  <>
+                                    <div className="twin-dot" style={{ background: dotColor }} />
+                                    <div className="twin-dot" style={{ background: dotColor }} />
+                                  </>
+                                )}
+                                {liveKind === 1 && <div className="snap-bar" style={{ background: takeColor }} />}
+                                {isPlayhead && <div className="cell-playhead" />}
                               </div>
-                            )}
-                            {v === 4 && (
-                              <>
-                                <div className="twin-dot" style={{ background: g.color }} />
-                                <div className="twin-dot" style={{ background: g.color }} />
-                              </>
-                            )}
-                            {flatBase[b] + s === playheadPos && <div className="cell-playhead" />}
-                          </div>
-                        );
-                      });
-                    })}
-                  </div>
-                </div>
-              ))}
-            </div>
-          ))}
+                            );
+                          });
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/dut-dut/src/components/ExplainModal.jsx
+++ b/dut-dut/src/components/ExplainModal.jsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { DESTINATIONS, sendTo, copyText, downloadMarkdown, fitsInUrl, encodedLength, URL_LIMIT } from '../handoff.js';
+import { COLORS } from '../constants.js';
+
+// `levels` is passed in rather than imported so that insights-engine.js stays a
+// lazily-loaded chunk instead of being pulled into the initial bundle.
+export default function ExplainModal({
+  open, onClose, text, levels = [], level, setLevel, scopeLabel, showDisclosure, onDismissDisclosure,
+}) {
+  const [status, setStatus] = useState('');
+  if (!open) return null;
+
+  const { accent, onAccent, mutedText } = COLORS;
+  const fits = fitsInUrl(text);
+
+  const handleSend = (dest) => {
+    const r = sendTo(dest, text);
+    setStatus(r.fellBack
+      ? `Too long to prefill — copied to your clipboard instead. Paste it into the ${dest.label} tab that just opened.`
+      : `Opened ${dest.label} with the pattern prefilled.`);
+  };
+  const handleCopy = () => {
+    copyText(text)
+      .then(() => setStatus('Copied to your clipboard — paste it into any assistant.'))
+      .catch(() => setStatus('Could not reach the clipboard — select the text above and copy manually.'));
+  };
+  const handleDownload = () => {
+    downloadMarkdown(text);
+    setStatus('Saved dut-dut-cadence.md.');
+  };
+
+  return (
+    <>
+      <div className="settings-backdrop" style={{ zIndex: 20 }} onClick={onClose} />
+      <div className="explain-modal" role="dialog" aria-label="Explain this pattern">
+        <div className="drawer-header">
+          <div className="drawer-title">Explain this pattern</div>
+          <button className="drawer-close" onClick={onClose}>×</button>
+        </div>
+
+        <div className="explain-body">
+          {showDisclosure && (
+            <div className="explain-disclosure">
+              <div className="explain-disclosure-title">Before you send this somewhere</div>
+              <ul>
+                <li><strong>What gets shared:</strong> the pattern you drew, your section names, and your tempo — shown in full below. Nothing about you, no account details.</li>
+                <li><strong>What it costs:</strong> this opens an assistant you already use and spends <em>your</em> credits or plan usage, not the app's. dut dut never calls an AI itself.</li>
+                <li><strong>Age requirements:</strong> assistants set their own minimums — claude.ai requires 18+, most others 13+ or parental consent. Check the service's terms before using it.</li>
+              </ul>
+              <button className="file-btn" style={{ flex: '0 0 auto', alignSelf: 'flex-start' }} onClick={onDismissDisclosure}>Got it</button>
+            </div>
+          )}
+
+          <div className="explain-controls">
+            <div className="explain-control">
+              <div className="drawer-section-title" style={{ marginBottom: 6 }}>Explain it for</div>
+              <div className="mini-track">
+                {levels.map(l => (
+                  <button
+                    key={l.id}
+                    onClick={() => setLevel(l.id)}
+                    style={{ background: level === l.id ? accent : 'transparent', color: level === l.id ? onAccent : mutedText }}
+                  >
+                    {l.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="explain-control">
+              <div className="drawer-section-title" style={{ marginBottom: 6 }}>Covering</div>
+              <div className="small-note" style={{ fontSize: 11 }}>{scopeLabel}</div>
+            </div>
+          </div>
+
+          <div className="drawer-section-title" style={{ marginBottom: 6 }}>Exactly what will be sent</div>
+          <pre className="explain-preview">{text}</pre>
+          <div className="small-note">
+            {text.length.toLocaleString()} characters.{' '}
+            {fits
+              ? 'Short enough to open prefilled in a chat.'
+              : `Too long to fit in a link (${encodedLength(text).toLocaleString()} encoded, limit ~${URL_LIMIT.toLocaleString()}) — sending will copy it and open an empty chat for you to paste into.`}
+          </div>
+
+          <div className="drawer-section-title" style={{ margin: '16px 0 6px' }}>Send it to</div>
+          <div className="explain-dests">
+            {DESTINATIONS.map(d => (
+              <button key={d.id} className="file-btn" onClick={() => handleSend(d)}>{d.label} ↗</button>
+            ))}
+          </div>
+          <div className="explain-dests" style={{ marginTop: 6 }}>
+            <button className="file-btn" onClick={handleCopy}>Copy for any tool</button>
+            <button className="file-btn" onClick={handleDownload}>Download .md</button>
+          </div>
+          <div className="small-note" style={{ marginTop: 8 }}>
+            Opens in a new tab and uses your own account and credits. Works with any assistant — including a local model — via copy.
+          </div>
+
+          {status && <div className="explain-status">{status}</div>}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/dut-dut/src/components/ExplainModal.jsx
+++ b/dut-dut/src/components/ExplainModal.jsx
@@ -44,7 +44,7 @@ export default function ExplainModal({
               <div className="explain-disclosure-title">Before you send this somewhere</div>
               <ul>
                 <li><strong>What gets shared:</strong> the pattern you drew, your section names, and your tempo — shown in full below. Nothing about you, no account details.</li>
-                <li><strong>What it costs:</strong> this opens an assistant you already use and spends <em>your</em> credits or plan usage, not the app's. dut dut never calls an AI itself.</li>
+                <li><strong>What it costs:</strong> nothing from dut dut — it never calls an AI itself. You are using the assistant's own free tier, or your account and credits if you are signed in. Some assistants will answer without an account at all.</li>
                 <li><strong>Age requirements:</strong> assistants set their own minimums — claude.ai requires 18+, most others 13+ or parental consent. Check the service's terms before using it.</li>
               </ul>
               <button className="file-btn" style={{ flex: '0 0 auto', alignSelf: 'flex-start' }} onClick={onDismissDisclosure}>Got it</button>
@@ -92,7 +92,7 @@ export default function ExplainModal({
             <button className="file-btn" onClick={handleDownload}>Download .md</button>
           </div>
           <div className="small-note" style={{ marginTop: 8 }}>
-            Opens in a new tab and uses your own account and credits. Works with any assistant — including a local model — via copy.
+            Opens in a new tab and runs on the assistant's free tier or your own account — never the app's. Works with any assistant, including a local model, via copy.
           </div>
 
           {status && <div className="explain-status">{status}</div>}

--- a/dut-dut/src/components/InsightsPanel.jsx
+++ b/dut-dut/src/components/InsightsPanel.jsx
@@ -39,9 +39,19 @@ function InsightCard({ card, variant }) {
   );
 }
 
-function LlmBits({ llmAvailable, onAskClaude, askClaudeLabel, llmText, llmLabel, variant }) {
+function LlmBits({ llmAvailable, onAskClaude, askClaudeLabel, llmText, llmLabel, variant, explainAvailable, onExplain }) {
   return (
     <>
+      {explainAvailable && (
+        <button
+          className="ask-claude-btn"
+          style={variant === 'bottom' ? { flex: '0 0 220px' } : undefined}
+          onClick={onExplain}
+        >
+          Explain this pattern elsewhere →
+        </button>
+      )}
+      {/* Only inside a Claude artifact, where inference is already available. */}
       {llmAvailable && (
         <button
           className="ask-claude-btn"

--- a/dut-dut/src/components/SettingsDrawer.jsx
+++ b/dut-dut/src/components/SettingsDrawer.jsx
@@ -3,12 +3,16 @@ import { GROUPS_META, COLORS } from '../constants.js';
 export default function SettingsDrawer({
   open, onClose, isMobile,
   tempo, setTempo, metronome, toggleMetronome, setViewport, clearSection,
+  selRow, tapMode, setTapMode, hasTake, clearTake, takeColor,
+  perPart, togglePerPart, anyOverride, resetAllSubs,
   swing, setSwing, muted, toggleMute,
   sections, addSection, renameSection, setSectionMeasures, deleteSection,
   onSaveProject, onLoadFile, onExportMidi, onExportWav, onExportPng, projectStatus, rendering,
 }) {
   const { accent, onAccent, mutedText, text } = COLORS;
   const canDelete = sections.length > 1;
+  const tapExactOn = tapMode === 'exact';
+  const tapStyle = (active) => ({ background: active ? takeColor : 'transparent', color: active ? onAccent : mutedText });
 
   return (
     <div
@@ -54,6 +58,49 @@ export default function SettingsDrawer({
             </div>
           </div>
           <button className="danger-btn" onClick={clearSection}>Clear active section</button>
+        </div>
+
+        <div>
+          <div className="drawer-section-title">Play along</div>
+          <div className="toggle-row">
+            <span>Space taps into</span>
+            <span className="tap-target-name" style={{ color: selRow ? takeColor : mutedText }}>{selRow ? selRow.label : 'nothing yet'}</span>
+          </div>
+          <div className="toggle-row">
+            <span>Timing</span>
+            <div className="mini-track">
+              <button onClick={() => setTapMode('exact')} style={tapStyle(tapExactOn)}>Exact</button>
+              <button onClick={() => setTapMode('quant')} style={tapStyle(!tapExactOn)}>Auto-rhythm</button>
+            </div>
+          </div>
+          <div className="small-note" style={{ marginBottom: 8 }}>
+            Hit Play, click a drum name in the grid, then tap Space in time. Exact keeps the moment you played;
+            auto-rhythm pulls each tap to the nearest subdivision. Taps use the current tool, so the accent tool taps accents.
+          </div>
+          <button className="file-btn full" disabled={!hasTake} style={{ opacity: hasTake ? 1 : 0.45 }} onClick={clearTake}>
+            Clear tapped notes in this section
+          </button>
+        </div>
+
+        <div>
+          <div className="drawer-section-title">Subdivisions</div>
+          <div className="toggle-row">
+            <span>Per-part row (÷)</span>
+            <button
+              className="pill-toggle"
+              onClick={togglePerPart}
+              style={{ background: perPart ? accent : 'transparent', color: perPart ? onAccent : mutedText }}
+            >
+              {perPart ? 'Shown' : 'Hidden'}
+            </button>
+          </div>
+          <div className="small-note" style={{ marginBottom: 8 }}>
+            The beat ruler sets every part at once. Turn this on to give the snares triplets while the basses stay
+            in sixteenths on the same beat.
+          </div>
+          <button className="file-btn full" disabled={!anyOverride} style={{ opacity: anyOverride ? 1 : 0.45 }} onClick={resetAllSubs}>
+            Reset all parts to the ruler
+          </button>
         </div>
 
         <div>

--- a/dut-dut/src/components/StaffPanel.jsx
+++ b/dut-dut/src/components/StaffPanel.jsx
@@ -3,9 +3,19 @@ import { buildStaffShapes } from '../staff.js';
 
 const INK = 'oklch(24% 0.015 260)';
 
-function StaffSvg({ sg, showPlayhead, playheadX }) {
+function StaffSvg({ sg, showPlayhead, playheadX, takeColor }) {
   return (
     <svg width={sg.width} height={sg.height} style={{ display: 'block' }}>
+      {sg.bands.map(bd => (
+        <rect
+          key={bd.key}
+          x={bd.x} y={bd.y} width={bd.w} height={bd.h} rx={5}
+          fill={bd.fill} opacity={bd.opacity}
+          style={{ cursor: 'help' }}
+          onMouseEnter={bd.enter}
+          onMouseLeave={bd.leave}
+        />
+      ))}
       {sg.lines.map((ln, i) => (
         <line key={i} x1={16} x2={sg.lineEndX} y1={ln.y} y2={ln.y} stroke="oklch(55% 0.02 260)" strokeWidth={1} />
       ))}
@@ -18,16 +28,6 @@ function StaffSvg({ sg, showPlayhead, playheadX }) {
       <text x={42} y={sg.ts2Y} fill={INK} style={{ font: '700 15px Georgia,serif' }}>4</text>
       {sg.measureNums.map(mn => (
         <text key={mn.n} x={mn.x} y={sg.numY} fill="oklch(55% 0.02 260)" style={{ font: 'italic 9px Georgia,serif' }}>{mn.n}</text>
-      ))}
-      {sg.bands.map(bd => (
-        <rect
-          key={bd.key}
-          x={bd.x} y={bd.y} width={bd.w} height={bd.h} rx={5}
-          fill={bd.fill} opacity={bd.opacity}
-          style={{ cursor: 'help' }}
-          onMouseEnter={bd.enter}
-          onMouseLeave={bd.leave}
-        />
       ))}
       {showPlayhead && (
         <line x1={playheadX} x2={playheadX} y1={0} y2={sg.height} stroke="oklch(58% 0.16 235)" strokeWidth={2} opacity={0.8} />
@@ -61,27 +61,36 @@ function StaffSvg({ sg, showPlayhead, playheadX }) {
       ) : (
         <ellipse key={nt.key} cx={nt.x} cy={nt.y} rx={5.2} ry={3.9} transform={`rotate(-18 ${nt.x} ${nt.y})`} fill={nt.fill} />
       ))}
+      {sg.unisons.map(un => (
+        <rect key={un.key} x={un.x} y={un.y} width={un.w} height={un.h} rx={un.rx} fill={un.fill} />
+      ))}
+      {sg.snapBars.map(sb => (
+        <line key={sb.key} x1={sb.x1} x2={sb.x2} y1={sb.y} y2={sb.y} stroke={takeColor} strokeWidth={2} />
+      ))}
+      {sg.takeTicks.map(tk => (
+        <line key={tk.key} x1={tk.x} x2={tk.x} y1={tk.y1} y2={tk.y2} stroke={takeColor} strokeWidth={1.4} />
+      ))}
     </svg>
   );
 }
 
 export default function StaffPanel({
-  style, isMobile, isPreview, section, subs, sectionNotes, tempo,
-  playing, onTogglePlay, playheadPos, resolvePos,
+  style, isMobile, isPreview, section, subsByGroup, sectionNotes, sectionLive, tempo,
+  playing, onTogglePlay, playBeat, unison = true, takeColor, hasTake = false,
   insights = [], showBands = false, focusId = null, focusColor = null, tintByGroup = null,
   onBandEnter, onBandLeave,
 }) {
   const beatW = isMobile ? 112 : 128;
   const leftPad = 60;
-
-  let playheadX = -100;
-  if (playheadPos >= 0) {
-    const { beat, sub, subCount } = resolvePos(playheadPos);
-    playheadX = leftPad + beat * beatW + sub * (beatW / subCount) + (beatW / subCount) / 2;
-  }
+  const playheadX = playBeat >= 0 ? leftPad + playBeat * beatW : -100;
 
   const staffGroups = GROUPS_META.map(g => {
-    const shapes = buildStaffShapes(g, g.rowDefs.map(rd => sectionNotes[rd.id]), subs, section.measures, beatW, leftPad);
+    const shapes = buildStaffShapes(
+      g,
+      g.rowDefs.map(rd => sectionNotes[rd.id]),
+      g.rowDefs.map(rd => sectionLive[rd.id]),
+      subsByGroup[g.id], section.measures, beatW, leftPad, { unison },
+    );
 
     // Translucent hover bands over each insight's target beats
     const bands = [];
@@ -109,9 +118,11 @@ export default function StaffPanel({
     }
 
     const tintSet = tintByGroup ? tintByGroup[g.id] : null;
-    const notes = shapes.notes.map(n => ({ ...n, fill: tintSet && tintSet.has(n.b) ? focusColor : INK }));
+    const tinted = (n) => (tintSet && tintSet.has(n.b) ? focusColor : n.live ? takeColor : INK);
+    const notes = shapes.notes.map(n => ({ ...n, fill: tinted(n) }));
+    const unisons = shapes.unisons.map(n => ({ ...n, fill: tinted(n) }));
 
-    return { id: g.id, name: g.name, color: g.color, shapes: { ...shapes, notes, bands } };
+    return { id: g.id, name: g.name, color: g.color, shapes: { ...shapes, notes, unisons, bands } };
   });
 
   return (
@@ -133,9 +144,16 @@ export default function StaffPanel({
           {staffGroups.map(sg => (
             <div key={sg.id} className="staff-group">
               <div className="staff-group-label" style={{ color: sg.color }}>{sg.name}</div>
-              <StaffSvg sg={sg.shapes} showPlayhead={playheadPos >= 0} playheadX={playheadX} />
+              <StaffSvg sg={sg.shapes} showPlayhead={playBeat >= 0} playheadX={playheadX} takeColor={takeColor} />
             </div>
           ))}
+          {hasTake && (
+            <div className="take-key">
+              <span><span className="take-key-dot" style={{ background: takeColor }} />tapped in live</span>
+              <span><span className="take-key-tick" style={{ background: takeColor }} />where you actually played it</span>
+              <span><span className="take-key-bar" style={{ background: takeColor }} />snapped to the grid</span>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/dut-dut/src/constants.js
+++ b/dut-dut/src/constants.js
@@ -5,6 +5,8 @@ export const GROUPS_META = [
   { id: 'bass', name: 'Basses', color: 'oklch(50% 0.15 150)', single: false, rowDefs: [1, 2, 3, 4, 5].map(n => ({ id: 'bass' + n, label: 'B' + n })) },
 ];
 export const ALL_ROWS = GROUPS_META.flatMap(g => g.rowDefs.map(r => ({ ...r, groupId: g.id, color: g.color })));
+export const ROW_GROUP = {};
+for (const r of ALL_ROWS) ROW_GROUP[r.id] = r.groupId;
 
 // Vertical staff position (px) for each row within its group's staff SVG.
 export const LANE_Y = {
@@ -24,6 +26,10 @@ export const TOOLS = [
 ];
 
 export const STORAGE_KEY = 'dut-dut-project-v2';
+
+// Live-tap metadata per cell: 0 painted, 1 snapped to the grid, >=2 free timing
+// (the fractional offset into the cell is meta - 2).
+export const TAKE_DEFAULT = '#c4552b';
 
 export const COLORS = {
   text: 'oklch(20% 0.015 260)',
@@ -52,6 +58,13 @@ export function makeSectionNotes(section) {
 
 export function makeBeatSubs(section) { return new Array(beatCount(section)).fill(4); }
 
+// Per-part subdivision overrides: 0 means "inherit the beat ruler".
+export function makeGroupSubs(section) {
+  const g = {};
+  for (const gm of GROUPS_META) g[gm.id] = new Array(beatCount(section)).fill(0);
+  return g;
+}
+
 export function resizeBeatArray(arr, count, makeItem) {
   const out = arr.slice(0, count);
   while (out.length < count) out.push(makeItem(out.length));
@@ -66,33 +79,45 @@ export function normalizeProject(p) {
     name: String(s.name || 'Section ' + (i + 1)),
     measures: Math.max(1, Math.min(16, Math.round(Number(s.measures) || 4))),
   }));
-  const beatSubs = {}, notes = {};
+  const beatSubs = {}, groupSubs = {}, notes = {}, live = {};
   for (const s of sections) {
     const count = s.measures * 4;
     const rawSubs = (p.beatSubs && p.beatSubs[s.id]) || [];
     const subs = [];
     for (let i = 0; i < count; i++) subs.push([2, 3, 4].includes(rawSubs[i]) ? rawSubs[i] : 4);
     beatSubs[s.id] = subs;
-    const rows = {};
+    const rawG = (p.groupSubs && p.groupSubs[s.id]) || {};
+    const gs = {};
+    for (const gm of GROUPS_META) {
+      const arr = rawG[gm.id] || [];
+      gs[gm.id] = Array.from({ length: count }, (_, i) => ([2, 3, 4].includes(arr[i]) ? arr[i] : 0));
+    }
+    groupSubs[s.id] = gs;
+    const rows = {}, lrows = {};
     for (const row of ALL_ROWS) {
       const rawBeats = (p.notes && p.notes[s.id] && p.notes[s.id][row.id]) || [];
-      const beatsArr = [];
+      const rawLive = (p.live && p.live[s.id] && p.live[s.id][row.id]) || [];
+      const beatsArr = [], liveArr = [];
       for (let b = 0; b < count; b++) {
+        const sc = gs[row.groupId][b] || subs[b];
         const raw = Array.isArray(rawBeats[b]) ? rawBeats[b] : [];
-        const na = new Array(subs[b]).fill(0);
-        for (let i = 0; i < Math.min(na.length, raw.length); i++) {
+        const rawL = Array.isArray(rawLive[b]) ? rawLive[b] : [];
+        const na = new Array(sc).fill(0), la = new Array(sc).fill(0);
+        for (let i = 0; i < Math.min(sc, raw.length); i++) {
           const v = Math.round(Number(raw[i]) || 0);
           na[i] = v >= 0 && v <= 5 ? v : 0;
+          const m = Number(rawL[i]) || 0;
+          la[i] = m >= 0 && m < 3 ? m : 0;
         }
-        beatsArr.push(na);
+        beatsArr.push(na); liveArr.push(la);
       }
-      rows[row.id] = beatsArr;
+      rows[row.id] = beatsArr; lrows[row.id] = liveArr;
     }
-    notes[s.id] = rows;
+    notes[s.id] = rows; live[s.id] = lrows;
   }
   const activeSectionId = sections.some(s => s.id === p.activeSectionId) ? p.activeSectionId : sections[0].id;
   return {
-    sections, beatSubs, notes, activeSectionId,
+    sections, beatSubs, groupSubs, notes, live, activeSectionId,
     tempo: Math.max(40, Math.min(240, Math.round(Number(p.tempo) || 120))),
     swing: Math.max(0, Math.min(100, Math.round(Number(p.swing) || 0))),
   };

--- a/dut-dut/src/download.js
+++ b/dut-dut/src/download.js
@@ -1,0 +1,12 @@
+// Dependency-free so that importing it never drags the audio/export code into
+// the initial bundle — both export-utils.js and handoff.js rely on that.
+export function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 5000);
+}

--- a/dut-dut/src/export-utils.js
+++ b/dut-dut/src/export-utils.js
@@ -24,6 +24,21 @@ const GROUP_ROWS = {
   Tenors: ['tenor1', 'tenor2', 'tenor3', 'tenor4', 'tenor5', 'tenor6'],
   Basses: ['bass1', 'bass2', 'bass3', 'bass4', 'bass5'],
 };
+const ROW_GROUP = { cymbal: 'cymbal', snare: 'snare' };
+for (let i = 1; i <= 6; i++) ROW_GROUP['tenor' + i] = 'tenor';
+for (let i = 1; i <= 5; i++) ROW_GROUP['bass' + i] = 'bass';
+
+// Effective subdivision for one part on one beat: per-part override, else the measure setting.
+function subsFor(project, sectionId, rowId, beat) {
+  const master = (project.beatSubs[sectionId] || [])[beat] || 4;
+  const ov = project.groupSubs && project.groupSubs[sectionId] && project.groupSubs[sectionId][ROW_GROUP[rowId]];
+  return (ov && ov[beat]) || master;
+}
+// Live-tap metadata: 0 painted, 1 snapped to grid, >=2 free timing with offset (m - 2) of a subdivision.
+function liveOffset(project, sectionId, rowId, beat, sub) {
+  const m = project.live && project.live[sectionId] && project.live[sectionId][rowId] && project.live[sectionId][rowId][beat] ? (project.live[sectionId][rowId][beat][sub] || 0) : 0;
+  return m >= 2 ? m - 2 : 0;
+}
 
 function vlq(n) {
   n = Math.max(0, Math.round(n));
@@ -39,7 +54,7 @@ function trackChunk(events) {
 }
 
 export function buildMidi(project) {
-  const { sections, beatSubs, notes, tempo } = project;
+  const { sections, notes, tempo } = project;
   const tempoTrack = [
     0, 0xff, 0x51, 0x03, ...u32(Math.round(60000000 / tempo)).slice(1),
     0, 0xff, 0x58, 0x04, 4, 2, 24, 8,
@@ -50,13 +65,13 @@ export function buildMidi(project) {
     const evts = [];
     let tickOff = 0;
     for (const s of sections) {
-      const subs = beatSubs[s.id];
-      for (let b = 0; b < subs.length; b++) {
-        const sc = subs[b];
-        const subTicks = PPQ / sc;
-        for (let sub = 0; sub < sc; sub++) {
-          const t = tickOff + b * PPQ + sub * subTicks;
-          for (const rowId of rowIds) {
+      const beats = s.measures * 4;
+      for (let b = 0; b < beats; b++) {
+        for (const rowId of rowIds) {
+          const sc = subsFor(project, s.id, rowId, b);
+          const subTicks = PPQ / sc;
+          for (let sub = 0; sub < sc; sub++) {
+            const t = tickOff + b * PPQ + sub * subTicks + liveOffset(project, s.id, rowId, b, sub) * subTicks;
             const v = notes[s.id]?.[rowId]?.[b]?.[sub];
             if (!v) continue;
             const note = NOTE_MAP[rowId];
@@ -109,7 +124,7 @@ function encodeWav(audioBuffer) {
 }
 
 export async function renderWav(project) {
-  const { sections, beatSubs, notes, tempo, swing } = project;
+  const { sections, notes, tempo, swing } = project;
   const beatDur = 60 / tempo;
   let total = 0.1;
   for (const s of sections) total += s.measures * 4 * beatDur;
@@ -117,16 +132,18 @@ export async function renderWav(project) {
   const players = buildVoicePlayers();
   let off = 0.05;
   for (const s of sections) {
-    const subs = beatSubs[s.id];
-    for (let b = 0; b < subs.length; b++) {
-      const sc = subs[b];
-      const dur = beatDur / sc;
-      for (let sub = 0; sub < sc; sub++) {
-        let t = off + b * beatDur + sub * dur;
-        if (sc % 2 === 0 && sub % 2 === 1) t += dur * (swing / 100) * 0.5;
-        for (const rowId in players) {
+    const beats = s.measures * 4;
+    for (let b = 0; b < beats; b++) {
+      for (const rowId in players) {
+        const sc = subsFor(project, s.id, rowId, b);
+        const dur = beatDur / sc;
+        for (let sub = 0; sub < sc; sub++) {
           const v = notes[s.id]?.[rowId]?.[b]?.[sub];
           if (!v) continue;
+          let t = off + b * beatDur + sub * dur;
+          const lo = liveOffset(project, s.id, rowId, b, sub);
+          if (lo) t += lo * dur;
+          else if (sc % 2 === 0 && sub % 2 === 1) t += dur * (swing / 100) * 0.5;
           const play = players[rowId];
           if (v === 1) play(ctx, t, ctx.destination, 1);
           else if (v === 2) play(ctx, t, ctx.destination, 2);
@@ -146,6 +163,7 @@ export async function renderWav(project) {
 const INK = '#16181f';
 const GRAY = '#7a7f8c';
 const LINE = '#565b68';
+const TAKE = '#c4552b';
 
 function drawShapes(ctx, s, ox, oy) {
   ctx.strokeStyle = LINE; ctx.lineWidth = 1;
@@ -184,6 +202,8 @@ function drawShapes(ctx, s, ox, oy) {
     ctx.beginPath(); ctx.moveTo(ox + gr.k1x, oy + gr.k1y); ctx.lineTo(ox + gr.k2x, oy + gr.k2y); ctx.stroke();
   }
   for (const nt of s.notes) {
+    ctx.fillStyle = nt.live ? TAKE : INK;
+    ctx.strokeStyle = nt.live ? TAKE : INK;
     if (nt.isX) {
       ctx.lineWidth = 1.7;
       ctx.beginPath(); ctx.moveTo(ox + nt.x1a, oy + nt.y1a); ctx.lineTo(ox + nt.x2a, oy + nt.y2a); ctx.stroke();
@@ -192,6 +212,17 @@ function drawShapes(ctx, s, ox, oy) {
       ctx.beginPath(); ctx.ellipse(ox + nt.x, oy + nt.y, 5.2, 3.9, -18 * Math.PI / 180, 0, Math.PI * 2); ctx.fill();
     }
   }
+  for (const un of s.unisons || []) {
+    ctx.fillStyle = un.live ? TAKE : INK;
+    ctx.beginPath();
+    if (ctx.roundRect) { ctx.roundRect(ox + un.x, oy + un.y, un.w, un.h, un.rx); ctx.fill(); }
+    else ctx.fillRect(ox + un.x, oy + un.y, un.w, un.h);
+  }
+  ctx.strokeStyle = TAKE;
+  ctx.lineWidth = 1.4;
+  for (const tk of s.takeTicks || []) { ctx.beginPath(); ctx.moveTo(ox + tk.x, oy + tk.y1); ctx.lineTo(ox + tk.x, oy + tk.y2); ctx.stroke(); }
+  ctx.lineWidth = 2;
+  for (const sb of s.snapBars || []) { ctx.beginPath(); ctx.moveTo(ox + sb.x1, oy + sb.y); ctx.lineTo(ox + sb.x2, oy + sb.y); ctx.stroke(); }
   ctx.textAlign = 'left';
 }
 

--- a/dut-dut/src/export-utils.js
+++ b/dut-dut/src/export-utils.js
@@ -1,16 +1,7 @@
 // Export helpers: MIDI file, rendered WAV audio, score PNG, file download.
 import { buildVoicePlayers } from './audio-engine.js';
 
-export function downloadBlob(blob, filename) {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  setTimeout(() => URL.revokeObjectURL(url), 5000);
-}
+export { downloadBlob } from './download.js';
 
 // ---------- MIDI ----------
 const PPQ = 480;

--- a/dut-dut/src/handoff.js
+++ b/dut-dut/src/handoff.js
@@ -1,0 +1,64 @@
+// handoff.js — send the cadence context to an assistant of the user's choosing.
+//
+// Design constraint: this app never calls an LLM itself. A claude.ai / ChatGPT
+// subscription cannot be used programmatically (only separately-metered API
+// credits can), so the only way to reach the subscription a user already pays
+// for is to hand the text into the chat UI where they are already signed in.
+// That also means the app makes zero network requests of its own — nothing
+// leaves the browser until the user deliberately sends it.
+import { downloadBlob } from './download.js';
+
+// These `?q=` parameters are undocumented per-vendor and can change without
+// notice. Clipboard is the guaranteed path and is always offered alongside.
+export const DESTINATIONS = [
+  { id: 'claude', label: 'Claude', blank: 'https://claude.ai/new', url: q => `https://claude.ai/new?q=${q}` },
+  { id: 'chatgpt', label: 'ChatGPT', blank: 'https://chatgpt.com/', url: q => `https://chatgpt.com/?q=${q}` },
+  { id: 'gemini', label: 'Gemini', blank: 'https://gemini.google.com/app', url: q => `https://gemini.google.com/app?q=${q}` },
+];
+
+// A typical single-section envelope encodes to ~3.3k, so the old 2k-ish "maximum
+// compatibility" ceiling would make every send fall back and the destination
+// buttons pointless. 4k is still well inside every modern browser (Chrome handles
+// ~32k) and leaves headroom under Apache's 8190-byte request-line default.
+// These destinations are SPAs that read `?q=` from location.search client-side,
+// so an over-long URL surfaces as a visible 414 from a CDN rather than a silent
+// truncation — and anything past this limit takes the copy path anyway.
+export const URL_LIMIT = 4000;
+
+export function encodedLength(text) {
+  return encodeURIComponent(text).length;
+}
+
+export function fitsInUrl(text) {
+  return encodedLength(text) <= URL_LIMIT;
+}
+
+export function buildUrl(dest, text) {
+  return dest.url(encodeURIComponent(text));
+}
+
+export function copyText(text) {
+  return navigator.clipboard.writeText(text);
+}
+
+export function downloadMarkdown(text, filename = 'dut-dut-cadence.md') {
+  downloadBlob(new Blob([text], { type: 'text/markdown' }), filename);
+}
+
+// Opens `dest` with the context prefilled when it fits in a URL. When it does
+// not, copies the text and opens an empty chat instead — never truncates, since
+// a silently clipped pattern would be explained wrongly.
+//
+// `open` and `copy` are injectable so the length-guard branch can be tested
+// without actually launching tabs.
+export function sendTo(dest, text, { open, copy } = {}) {
+  const doOpen = open || (u => window.open(u, '_blank', 'noopener,noreferrer'));
+  const doCopy = copy || copyText;
+  const fits = fitsInUrl(text);
+  // Must happen synchronously inside the click handler — awaiting the clipboard
+  // first loses the user-gesture context and trips popup blockers.
+  const url = fits ? buildUrl(dest, text) : dest.blank;
+  doOpen(url);
+  if (!fits) doCopy(text);
+  return { fellBack: !fits, url };
+}

--- a/dut-dut/src/insights-engine.js
+++ b/dut-dut/src/insights-engine.js
@@ -34,10 +34,11 @@ const NEUTRAL = 'oklch(60% 0.02 260)';
 // value bits: 1 hit, 2 accent, 4 flam, 8 diddle, 16 buzz
 const VBIT = { 1: 1, 2: 2, 3: 4, 4: 8, 5: 16 };
 
-function digest(sec, subs, notesForSec, groups, rows) {
+function digest(sec, subs, notesForSec, groups, rows, gsubs) {
   const beats = sec.measures * 4;
+  const scOf = (gid, b) => ((gsubs && gsubs[gid] && gsubs[gid][b]) || subs[b] || 4);
   const byGroup = {};
-  for (const g of groups) byGroup[g.id] = Array.from({ length: beats }, (_, b) => ({ sc: subs[b] || 4, m: new Array(subs[b] || 4).fill(0) }));
+  for (const g of groups) byGroup[g.id] = Array.from({ length: beats }, (_, b) => ({ sc: scOf(g.id, b), m: new Array(scOf(g.id, b)).fill(0) }));
   for (const r of rows) {
     const beatsArr = (notesForSec && notesForSec[r.id]) || [];
     for (let b = 0; b < beats; b++) {
@@ -59,8 +60,8 @@ function runs(beatIdxs) {
 }
 const t = (...keys) => keys.map(k => TERMS[k]);
 
-function analyzeSection(sec, subs, notesForSec, groups, rows) {
-  const { beats, byGroup } = digest(sec, subs, notesForSec, groups, rows);
+function analyzeSection(sec, subs, notesForSec, groups, rows, gsubs, liveForSec) {
+  const { beats, byGroup } = digest(sec, subs, notesForSec, groups, rows, gsubs);
   const out = [];
   const tgt = (groupId, beatList) => ({ sectionId: sec.id, groupId, beats: beatList });
   const gname = id => (groups.find(g => g.id === id) || {}).name || id;
@@ -121,9 +122,50 @@ function analyzeSection(sec, subs, notesForSec, groups, rows) {
       break;
     }
   }
+  // Mixed subdivisions between parts (per-part subdivision writing)
+  {
+    const mixed = [];
+    for (let b = 0; b < beats; b++) {
+      const scs = new Set();
+      for (const g of groups) { const c = byGroup[g.id][b]; if (c.m.some(v => v)) scs.add(c.sc); }
+      if (scs.size >= 2) mixed.push(b);
+    }
+    if (mixed.length) {
+      out.push({ kind: 'crossdiv', sectionId: sec.id, title: 'Two subdivisions at once', body: 'On the highlighted beats one part splits the beat into three while another splits it into four. Two different grids running against each other inside the same pulse is a cross-rhythm — the effect is a shimmer that resolves every time the parts meet on the downbeat.', terms: t('polyrhythm', 'hemiola', 'triplet'), targets: [tgt(null, mixed)] });
+    }
+  }
+  // Timing of a live play-along take
+  if (liveForSec) {
+    let n = 0, sumMs = 0, worst = 0; const takeBeats = [];
+    const beatMs = 60000 / (sec._tempo || 120);
+    for (const r of rows) {
+      const larr = liveForSec[r.id] || [];
+      for (let b = 0; b < beats; b++) {
+        const cell = larr[b] || [];
+        const sc = byGroup[r.groupId] ? byGroup[r.groupId][b].sc : 4;
+        for (let s = 0; s < cell.length; s++) {
+          const m = cell[s] || 0;
+          if (m < 2) continue;
+          const off = m - 2;
+          const dev = (off <= 0.5 ? off : off - 1) * (beatMs / sc);
+          n++; sumMs += dev; if (Math.abs(dev) > Math.abs(worst)) worst = dev;
+          takeBeats.push(b);
+        }
+      }
+    }
+    if (n >= 4) {
+      const avg = sumMs / n;
+      const lean = avg > 8 ? 'a touch behind the grid' : avg < -8 ? 'slightly ahead of the grid' : 'right on top of the grid';
+      out.push({ kind: 'take', sectionId: sec.id, title: 'Your take, measured', body: 'Of the ' + n + ' notes you tapped in freely, the average landed ' + lean + ' (' + (avg >= 0 ? '+' : '') + Math.round(avg) + ' ms), the loosest by ' + Math.round(Math.abs(worst)) + ' ms. Small, consistent lateness reads as laid-back feel; scattered error reads as unsteady. Switch to auto-rhythm to hear the same idea locked to the grid.', terms: t('beat', 'groove', 'swing'), targets: [tgt(null, takeBeats)] });
+    }
+  }
   // Triplet vs straight subdivisions
   const tripBeats = [], eighthBeats = [];
-  for (let b = 0; b < beats; b++) { if ((subs[b] || 4) === 3) tripBeats.push(b); else if ((subs[b] || 4) === 2) eighthBeats.push(b); }
+  for (let b = 0; b < beats; b++) {
+    let three = false, two = false;
+    for (const g of groups) { const c = byGroup[g.id][b]; if (c.sc === 3) three = true; else if (c.sc === 2) two = true; }
+    if (three) tripBeats.push(b); else if (two) eighthBeats.push(b);
+  }
   if (tripBeats.length && tripBeats.length < beats) {
     out.push({ kind: 'triplets', sectionId: sec.id, title: 'Duple meets triple', body: 'The highlighted beats divide into triplets — three equal notes where the neighbors have four sixteenths' + (eighthBeats.length ? ' or two eighths' : '') + '. Switching the subdivision mid-phrase flips the feel from square to rolling.', terms: t('triplet', 'sixteenth'), targets: [tgt(null, tripBeats)] });
   } else if (tripBeats.length === beats) {
@@ -201,7 +243,7 @@ function analyzeSection(sec, subs, notesForSec, groups, rows) {
 }
 
 export function analyzeProject(project, opts) {
-  const { sections, beatSubs, notes, tempo, swing } = project;
+  const { sections, beatSubs, groupSubs, notes, live, tempo, swing } = project;
   const { scope, activeSectionId, groups, rows } = opts;
   const secList = scope === 'cadence' ? sections : sections.filter(s => s.id === activeSectionId);
   const out = [];
@@ -216,11 +258,11 @@ export function analyzeProject(project, opts) {
   if (swing > 0) {
     out.push({ kind: 'swing', sectionId: null, title: 'Swung, not straight', body: 'Swing is set to ' + swing + '%, so every other subdivision plays late. The notation stays even but the feel shuffles — the lilt you hear in jazz and hip-hop.', terms: t('swing', 'groove'), targets: [] });
   }
-  for (const sec of secList) out.push(...analyzeSection(sec, beatSubs[sec.id] || [], notes[sec.id] || {}, groups, rows));
+  for (const sec of secList) out.push(...analyzeSection({ ...sec, _tempo: tempo }, beatSubs[sec.id] || [], notes[sec.id] || {}, groups, rows, (groupSubs || {})[sec.id], (live || {})[sec.id]));
   // Cadence-wide dynamic arc
   if (scope === 'cadence' && sections.length >= 2) {
     const dens = sections.map(s => {
-      const d = digest(s, beatSubs[s.id] || [], notes[s.id] || {}, groups, rows);
+      const d = digest(s, beatSubs[s.id] || [], notes[s.id] || {}, groups, rows, (groupSubs || {})[s.id]);
       let sounded = 0, total = 0;
       for (const g of groups) d.byGroup[g.id].forEach(c => { total += c.sc; c.m.forEach(v => { if (v) sounded++; }); });
       return { s, v: total ? sounded / total : 0 };
@@ -244,12 +286,12 @@ export function analyzeProject(project, opts) {
 
 // Compact text description + teaching prompt for an LLM.
 export function buildLLMPrompt(project, opts) {
-  const { sections, beatSubs, notes, tempo, swing } = project;
+  const { sections, beatSubs, groupSubs, notes, tempo, swing } = project;
   const { scope, activeSectionId, groups, rows } = opts;
   const secList = scope === 'cadence' ? sections : sections.filter(s => s.id === activeSectionId);
   const lines = ['Tempo ' + tempo + ' BPM, 4/4 time' + (swing ? ', swing ' + swing + '%' : '') + '.'];
   for (const sec of secList) {
-    const { beats, byGroup } = digest(sec, beatSubs[sec.id] || [], notes[sec.id] || {}, groups, rows);
+    const { beats, byGroup } = digest(sec, beatSubs[sec.id] || [], notes[sec.id] || {}, groups, rows, (groupSubs || {})[sec.id]);
     lines.push('Section "' + sec.name + '" (' + sec.measures + ' measures):');
     for (const g of groups) {
       let any = false;

--- a/dut-dut/src/insights-engine.js
+++ b/dut-dut/src/insights-engine.js
@@ -284,20 +284,88 @@ export function analyzeProject(project, opts) {
   return capped;
 }
 
-// Compact text description + teaching prompt for an LLM.
-export function buildLLMPrompt(project, opts) {
-  const { sections, beatSubs, groupSubs, notes, tempo, swing } = project;
+// ---------------------------------------------------------------------------
+// Portable context envelope
+//
+// A self-describing description of the cadence that any assistant can consume —
+// MCP's spirit (a well-specified context contract) without requiring a server.
+// Deliberately human-readable: the user previews this exact text before it is
+// sent anywhere, so it has to be auditable by a person, not just a model.
+// ---------------------------------------------------------------------------
+
+export const LEVELS = [
+  { id: 'new', label: 'New to this' },
+  { id: 'playing', label: 'I play' },
+  { id: 'deep', label: 'Go deeper' },
+];
+
+const SUB_NAME = { 4: '16th notes', 3: 'triplets', 2: '8th notes' };
+
+// "16th notes" or "16th notes; triplets on beats 2, 6" — voices can now carry
+// their own subdivision per beat, so an even character count per beat is not
+// something the reader can assume.
+function describeSubs(scPerBeat) {
+  const uniq = [...new Set(scPerBeat)];
+  if (uniq.length === 1) return SUB_NAME[uniq[0]] || 'mixed';
+  const counts = uniq.map(u => ({ u, n: scPerBeat.filter(x => x === u).length })).sort((a, b) => b.n - a.n);
+  const parts = [SUB_NAME[counts[0].u] || 'mixed'];
+  for (const { u } of counts.slice(1)) {
+    const bs = scPerBeat.map((c, i) => (c === u ? i + 1 : 0)).filter(Boolean);
+    parts.push((SUB_NAME[u] || 'mixed') + ' on beat' + (bs.length > 1 ? 's' : '') + ' ' + bs.join(', '));
+  }
+  return parts.join('; ');
+}
+
+// Aggregate timing of a live play-along take, if one exists for this section.
+function takeSummary(sec, liveForSec, byGroup, rows, tempo) {
+  if (!liveForSec) return null;
+  const beats = sec.measures * 4;
+  const beatMs = 60000 / (tempo || 120);
+  let free = 0, snapped = 0, sumMs = 0, worst = 0;
+  const perBeat = {};
+  for (const r of rows) {
+    const larr = liveForSec[r.id] || [];
+    for (let b = 0; b < beats; b++) {
+      const cell = larr[b] || [];
+      const sc = byGroup[r.groupId] ? byGroup[r.groupId][b].sc : 4;
+      for (let s = 0; s < cell.length; s++) {
+        const m = cell[s] || 0;
+        if (m === 1) { snapped++; continue; }
+        if (m < 2) continue;
+        const off = m - 2;
+        const dev = (off <= 0.5 ? off : off - 1) * (beatMs / sc);
+        free++; sumMs += dev;
+        if (Math.abs(dev) > Math.abs(worst)) worst = dev;
+        (perBeat[b] = perBeat[b] || []).push(dev);
+      }
+    }
+  }
+  if (!free && !snapped) return null;
+  const avg = free ? sumMs / free : 0;
+  // Beats where the player was most consistently off — useful coaching signal.
+  const drift = Object.entries(perBeat)
+    .map(([b, devs]) => ({ beat: Number(b) + 1, avg: devs.reduce((x, y) => x + y, 0) / devs.length }))
+    .filter(d => Math.abs(d.avg) > 15)
+    .sort((a, b) => Math.abs(b.avg) - Math.abs(a.avg))
+    .slice(0, 3);
+  return { free, snapped, avgMs: Math.round(avg), worstMs: Math.round(worst), drift };
+}
+
+export function buildCadenceContext(project, opts) {
+  const { sections, beatSubs, groupSubs, notes, live, tempo, swing } = project;
   const { scope, activeSectionId, groups, rows } = opts;
   const secList = scope === 'cadence' ? sections : sections.filter(s => s.id === activeSectionId);
-  const lines = ['Tempo ' + tempo + ' BPM, 4/4 time' + (swing ? ', swing ' + swing + '%' : '') + '.'];
-  for (const sec of secList) {
+
+  const outSections = secList.map(sec => {
     const { beats, byGroup } = digest(sec, beatSubs[sec.id] || [], notes[sec.id] || {}, groups, rows, (groupSubs || {})[sec.id]);
-    lines.push('Section "' + sec.name + '" (' + sec.measures + ' measures):');
+    const voices = [];
     for (const g of groups) {
       let any = false;
       const parts = [];
+      const scPerBeat = [];
       for (let b = 0; b < beats; b++) {
         const c = byGroup[g.id][b];
+        scPerBeat.push(c.sc);
         let cell = '';
         c.m.forEach(v => {
           if (!v) { cell += '.'; return; }
@@ -305,14 +373,113 @@ export function buildLLMPrompt(project, opts) {
           cell += (v & 2) ? '>' : (v & 4) ? 'f' : (v & 8) ? 'd' : (v & 16) ? 'z' : 'x';
         });
         if (c.sc === 3) cell = '[' + cell + ']';
+        else if (c.sc === 2) cell = '(' + cell + ')';
         parts.push(cell);
         if (b % 4 === 3 && b < beats - 1) parts.push('|');
       }
-      if (any) lines.push('  ' + g.name + ': ' + parts.join(' '));
+      if (any) voices.push({ name: g.name, line: parts.join(' '), subs: describeSubs(scPerBeat) });
+    }
+    return {
+      name: sec.name,
+      measures: sec.measures,
+      voices,
+      take: takeSummary(sec, (live || {})[sec.id], byGroup, rows, tempo),
+    };
+  });
+
+  return {
+    app: 'dut dut',
+    tempo, swing, timeSig: '4/4',
+    scope: scope === 'cadence' ? 'cadence' : 'section',
+    sections: outSections,
+    findings: analyzeProject(project, opts).filter(i => i.kind !== 'basics').map(i => i.title),
+  };
+}
+
+const LEVEL_ASK = {
+  new: `I'm new to music theory — assume I can hear rhythm but can't read notation.
+
+In 4-6 plain sentences, help me understand what I've written: what gives it its feel, one comparison to music I'd likely have heard, one thing that's already working, and one concrete change to try next. Define at most two terms in passing, in plain words. No jargon I'd have to look up, no markdown, no lists, no headings.`,
+
+  playing: `I play and can read basic drum notation — skip the fundamentals.
+
+In 5-8 sentences: what makes this pattern work rhythmically; a suggested sticking (which hand plays what, R/L) for the busiest voice; whether this is realistically playable at the tempo above and where the hard spot is; and one arranging change that would improve it. Be specific about beat numbers. No markdown, no lists.`,
+
+  deep: `I know the fundamentals — go deep.
+
+Cover the metric structure and where the phrase resolves, any stylistic lineage this evokes (corps, street, HBCU idiom) and why, and a critique of the arranging: voice balance across the line, tension and release, and whether each part is idiomatic for its instrument. Flag anything unidiomatic or physically awkward. Prose, no markdown, no lists.`,
+};
+
+export function renderContextMarkdown(ctx, { level = 'new' } = {}) {
+  const L = [];
+  L.push('# Drumline cadence — context for explanation');
+  L.push('');
+  L.push(`I sketched this drum pattern in **dut dut**, a step sequencer for drumline cadences, and I'd like help understanding it musically. Everything you need is below.`);
+  L.push('');
+
+  L.push('## How to read the notation');
+  L.push('');
+  L.push('Each line is one voice of the drumline. Characters are consecutive slices of a beat, `|` separates measures, and beats are space-separated:');
+  L.push('');
+  L.push('- `.` rest · `x` hit · `>` accented hit · `f` flam (grace note before the stroke) · `d` diddle (two strokes in one slot) · `z` buzz roll');
+  L.push('- A beat with no brackets is **four 16th notes**. `[...]` marks a **triplet** beat, `(..)` marks a beat of **two 8th notes**.');
+  L.push('- Voices can use *different* subdivisions on the same beat, so lines will not always have equal character counts. Each voice notes its own subdivisions.');
+  L.push('');
+
+  L.push('## The pattern');
+  L.push('');
+  L.push(`Tempo **${ctx.tempo} BPM** · ${ctx.timeSig}${ctx.swing ? ` · swing ${ctx.swing}%` : ''}`);
+  L.push('');
+
+  for (const sec of ctx.sections) {
+    L.push(`### "${sec.name}" — ${sec.measures} measure${sec.measures === 1 ? '' : 's'}`);
+    L.push('');
+    if (!sec.voices.length) {
+      L.push('_(nothing written in this section yet)_');
+      L.push('');
+      continue;
+    }
+    L.push('```');
+    const pad = Math.max(...sec.voices.map(v => v.name.length));
+    for (const v of sec.voices) L.push(`${v.name.padEnd(pad)} : ${v.line}`);
+    L.push('```');
+    L.push('');
+    for (const v of sec.voices) L.push(`- **${v.name}** — ${v.subs}`);
+    L.push('');
+    if (sec.take) {
+      const t2 = sec.take;
+      L.push(`**My live take:** I played ${t2.free + t2.snapped} of these notes in by hand` +
+        (t2.snapped ? ` (${t2.snapped} snapped to the grid, ${t2.free} kept at free timing)` : '') + '.');
+      if (t2.free) {
+        L.push(`Average timing was ${t2.avgMs >= 0 ? '+' : ''}${t2.avgMs} ms against the grid (positive = behind the beat), loosest note ${t2.worstMs >= 0 ? '+' : ''}${t2.worstMs} ms.`);
+        if (t2.drift.length) {
+          L.push('Consistently off on: ' + t2.drift.map(d => `beat ${d.beat} (${d.avg >= 0 ? '+' : ''}${Math.round(d.avg)} ms)`).join(', ') + '.');
+        }
+        L.push('Please comment on my timing too.');
+      }
+      L.push('');
     }
   }
-  const findings = analyzeProject(project, opts).filter(i => i.kind !== 'basics').map(i => i.title);
-  return 'You are a friendly percussion educator helping a beginner understand a drumline pattern they just sketched in a step sequencer. Symbols per subdivision: . rest, x hit, > accented hit, f flam, d diddle (two strokes), z buzz roll. [..] means that beat is a triplet. | separates measures.\n\n' +
-    lines.join('\n') + '\n\nAlready-detected features: ' + (findings.length ? findings.join('; ') : 'none') + '.\n\n' +
-    'In 3-5 short, plain sentences: explain what makes this pattern tick musically (go beyond the detected list where you can), define at most one term in passing, and end with one concrete thing to try next. Warm and encouraging, no markdown, no lists, no headings.';
+
+  L.push(`## What the app's built-in analyzer already spotted`);
+  L.push('');
+  if (ctx.findings.length) {
+    for (const f of ctx.findings) L.push(`- ${f}`);
+    L.push('');
+    L.push('_Please go past these rather than restating them._');
+  } else {
+    L.push('_Nothing notable detected — the pattern may be sparse or unusual._');
+  }
+  L.push('');
+
+  L.push('## What I would like');
+  L.push('');
+  L.push(LEVEL_ASK[level] || LEVEL_ASK.new);
+
+  return L.join('\n');
+}
+
+// Back-compat wrapper for the in-artifact `window.claude.complete` path.
+export function buildLLMPrompt(project, opts) {
+  return renderContextMarkdown(buildCadenceContext(project, opts), { level: (opts && opts.level) || 'new' });
 }

--- a/dut-dut/src/staff.js
+++ b/dut-dut/src/staff.js
@@ -1,15 +1,18 @@
 import { LANE_Y } from './constants.js';
 
 // Computes all staff-notation geometry (noteheads, stems, beams, flags, tuplets,
-// accents, diddle slashes, buzz z's, grace notes) for one group's staff.
+// accents, diddle slashes, buzz z's, grace notes, unison bars, live-take marks)
+// for one group's staff.
 // Pure — used by both the on-screen SVG staff and the PNG score export.
-export function buildStaffShapes(g, rowsArr, subs, measures, beatW, leftPad) {
+export function buildStaffShapes(g, rowsArr, liveRows, subs, measures, beatW, leftPad, opts) {
+  const unisonOn = (opts || {}).unison !== false;
   const beats = measures * 4;
   const laneYs = LANE_Y[g.id];
   const single = g.single;
   const staffH = single ? 84 : 134;
   const lines = single ? [{ y: 56 }] : [44, 60, 76, 92, 108].map(y => ({ y }));
   const midY = single ? 56 : 76;
+  const barBot = single ? 68 : 108;
   const lineEndX = leftPad + beats * beatW + 2;
   const barlines = [];
   for (let m = 0; m <= measures; m++) {
@@ -20,7 +23,13 @@ export function buildStaffShapes(g, rowsArr, subs, measures, beatW, leftPad) {
   const measureNums = [];
   for (let m = 0; m < measures; m++) measureNums.push({ x: leftPad + m * 4 * beatW + 4, n: m + 1 });
 
-  const notes = [], stems = [], beams = [], beams2 = [], flags = [], tuplets = [], accents = [], slashes = [], zs = [], graces = [];
+  // A unison is every drum this part actually uses hitting together — notated as one
+  // elongated notehead spanning the staff, as bass and tenor books do.
+  const activeLanes = new Set();
+  rowsArr.forEach((beatArr, laneIdx) => { if (beatArr.some(cell => cell.some(v => v))) activeLanes.add(laneIdx); });
+  const unisonEligible = unisonOn && !single && activeLanes.size >= 3;
+
+  const notes = [], stems = [], beams = [], beams2 = [], flags = [], tuplets = [], accents = [], slashes = [], zs = [], graces = [], unisons = [], takeTicks = [], snapBars = [];
   for (let b = 0; b < beats; b++) {
     const sc = subs[b];
     const subW = beatW / sc;
@@ -28,7 +37,12 @@ export function buildStaffShapes(g, rowsArr, subs, measures, beatW, leftPad) {
     for (let s = 0; s < sc; s++) {
       const x = leftPad + b * beatW + s * subW + subW / 2;
       const lanes = [];
-      rowsArr.forEach((beatArr, laneIdx) => { const v = beatArr[b][s]; if (v) lanes.push({ laneIdx, v }); });
+      rowsArr.forEach((beatArr, laneIdx) => {
+        const v = beatArr[b][s];
+        if (!v) return;
+        const lr = liveRows && liveRows[laneIdx] && liveRows[laneIdx][b];
+        lanes.push({ laneIdx, v, live: (lr && lr[s]) || 0 });
+      });
       positions.push({ s, x, lanes, sounded: lanes.length > 0 });
     }
     let beatMinStemTop = Infinity;
@@ -46,25 +60,36 @@ export function buildStaffShapes(g, rowsArr, subs, measures, beatW, leftPad) {
       run.forEach(p => {
         beatHasNotes = true;
         let maxHeadY = -Infinity, pMinHeadY = Infinity;
-        let hasAccent = false, hasDiddle = false, hasRoll = false;
+        let hasAccent = false, hasDiddle = false, hasRoll = false, anyLive = false;
+        const isUni = unisonEligible && p.lanes.length === activeLanes.size && p.lanes.every(l => activeLanes.has(l.laneIdx));
         p.lanes.forEach(l => {
           const y = laneYs[l.laneIdx];
           maxHeadY = Math.max(maxHeadY, y); pMinHeadY = Math.min(pMinHeadY, y);
           if (l.v === 2) hasAccent = true;
           if (l.v === 4) hasDiddle = true;
           if (l.v === 5) hasRoll = true;
+          if (l.live) anyLive = true;
+          if (l.live >= 2) takeTicks.push({ key: g.id + '-tk-' + b + '-' + p.s + '-' + l.laneIdx, x: p.x + (l.live - 2) * subW, y1: barBot + 4, y2: barBot + 12 });
+          else if (l.live === 1) snapBars.push({ key: g.id + '-sb-' + b + '-' + p.s + '-' + l.laneIdx, x1: p.x - 4.5, x2: p.x + 4.5, y: barBot + 8 });
           if (l.v === 3) {
             const gx = p.x - 12, gy = y, gsx = gx + 3.2;
             graces.push({ key: g.id + '-gr-' + b + '-' + p.s + '-' + l.laneIdx, x: gx, y: gy, sx: gsx, sy1: gy - 1, sy2: gy - 13, k1x: gsx - 3, k1y: gy - 5, k2x: gsx + 3.5, k2y: gy - 11 });
           }
+          if (isUni) return;
           const isX = g.id === 'cymbal';
           notes.push({
             key: g.id + '-n-' + b + '-' + p.s + '-' + l.laneIdx,
-            b, x: p.x, y, isX, isOval: !isX,
+            b, x: p.x, y, isX, isOval: !isX, live: !!l.live,
             x1a: p.x - 4.6, y1a: y - 4.6, x2a: p.x + 4.6, y2a: y + 4.6,
             x1b: p.x - 4.6, y1b: y + 4.6, x2b: p.x + 4.6, y2b: y - 4.6,
           });
         });
+        if (isUni) {
+          const ys = p.lanes.map(l => laneYs[l.laneIdx]);
+          const top = Math.min.apply(null, ys), bot = Math.max.apply(null, ys);
+          unisons.push({ key: g.id + '-un-' + b + '-' + p.s, b, x: p.x - 4.7, y: top - 4.3, w: 9.4, h: (bot - top) + 8.6, rx: 4.7, live: anyLive });
+          maxHeadY = top - 4.3; pMinHeadY = top;
+        }
         const stemTop = beamed ? stemTopBeamed : pMinHeadY - 20;
         beatMinStemTop = Math.min(beatMinStemTop, stemTop);
         const stemX = p.x + 4.8;
@@ -95,8 +120,8 @@ export function buildStaffShapes(g, rowsArr, subs, measures, beatW, leftPad) {
   return {
     width: lineEndX + 16, height: staffH,
     lineEndX, lines, barlines, measureNums,
-    barTop: 44, barBot: single ? 68 : 108,
+    barTop: 44, barBot,
     clefY: midY - 8, ts1Y: midY - 2, ts2Y: midY + 13, numY: staffH - 4,
-    notes, stems, beams, beams2, flags, tuplets, accents, slashes, zs, graces,
+    notes, stems, beams, beams2, flags, tuplets, accents, slashes, zs, graces, unisons, takeTicks, snapBars,
   };
 }

--- a/dut-dut/src/styles.css
+++ b/dut-dut/src/styles.css
@@ -223,11 +223,61 @@ a:hover {
   font-weight: 600;
   cursor: pointer;
 }
-.hint-text {
+.hint-row {
   flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 0 16px 8px;
+}
+.hint-text {
   font-size: 10px;
   color: oklch(55% 0.02 260);
-  padding: 0 16px 8px;
+}
+.hint-right {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-left: auto;
+}
+.tap-target-pill {
+  border: 1px solid oklch(85% 0.012 80);
+  border-radius: 20px;
+  padding: 4px 10px;
+  font-size: 10px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.take-legend-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.take-legend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 9px;
+  color: oklch(50% 0.02 260);
+  white-space: nowrap;
+}
+.take-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.clear-take-btn {
+  border: 1px solid oklch(85% 0.012 80);
+  background: transparent;
+  color: oklch(46% 0.02 260);
+  border-radius: 20px;
+  padding: 4px 10px;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
 }
 .blocks-scroll {
   flex: 1;
@@ -251,6 +301,19 @@ a:hover {
   z-index: 4;
   background: oklch(97% 0.007 80);
   border-bottom: 1px solid oklch(85% 0.012 80);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.perpart-btn {
+  border: 1px solid oklch(85% 0.012 80);
+  border-radius: 6px;
+  height: 20px;
+  padding: 0 7px;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
 }
 .ruler-btn {
   flex-shrink: 0;
@@ -274,7 +337,7 @@ a:hover {
   font-size: 9px;
   font-weight: 600;
   border-radius: 4px;
-  padding: 1px 4px;
+  padding: 0 4px;
 }
 .group-header {
   display: flex;
@@ -307,6 +370,78 @@ a:hover {
   border: 1px solid oklch(85% 0.012 80);
   cursor: pointer;
 }
+.arm-btn {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 3px 9px;
+  border-radius: 6px;
+  border: 1px solid oklch(85% 0.012 80);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.tap-mode-track {
+  display: flex;
+  background: oklch(94% 0.01 80);
+  border: 1px solid oklch(85% 0.012 80);
+  border-radius: 7px;
+  padding: 2px;
+  gap: 2px;
+}
+.tap-mode-track button {
+  border: none;
+  border-radius: 5px;
+  padding: 3px 8px;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.own-subs-btn {
+  font-size: 9px;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 6px;
+  border: 1px solid;
+  background: transparent;
+  cursor: pointer;
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+}
+
+/* Per-part subdivision row */
+.subchip-row {
+  align-items: stretch;
+}
+.subchip-label {
+  width: 56px;
+  flex: 0 0 56px;
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background: oklch(98% 0.006 80);
+  display: flex;
+  align-items: center;
+  padding-left: 14px;
+  font-size: 9px;
+  color: oklch(58% 0.02 260);
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+}
+.subchip-btn {
+  flex-shrink: 0;
+  height: 22px;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+.subchip-pill {
+  font-size: 9px;
+  font-weight: 700;
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  border-radius: 4px;
+  padding: 0 5px;
+}
+
 .row-line {
   display: flex;
   align-items: stretch;
@@ -316,14 +451,15 @@ a:hover {
   flex: 0 0 56px;
   display: flex;
   align-items: center;
-  padding-left: 14px;
+  padding: 0 0 0 14px;
   font-size: 11px;
-  color: oklch(46% 0.02 260);
   font-family: 'IBM Plex Mono', ui-monospace, monospace;
-  background: oklch(98% 0.006 80);
   position: sticky;
   left: 0;
   z-index: 2;
+  border: none;
+  border-bottom: 1px solid oklch(89% 0.01 80);
+  cursor: pointer;
 }
 .row-cells {
   display: flex;
@@ -371,6 +507,22 @@ a:hover {
   position: absolute;
   inset: 0;
   background: rgba(20, 20, 30, 0.09);
+}
+/* Live-tap marks: how far the played note sat from the grid slot */
+.dev-line {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  height: 1.5px;
+  opacity: 0.6;
+}
+.snap-bar {
+  position: absolute;
+  bottom: 3px;
+  left: 50%;
+  margin-left: -6px;
+  width: 12px;
+  height: 2px;
 }
 
 /* Staff panel */
@@ -437,6 +589,35 @@ a:hover {
 }
 .staff-group svg {
   display: block;
+}
+.take-key {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 2px 0 6px;
+  font-size: 10px;
+  color: oklch(50% 0.02 260);
+}
+.take-key > span {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.take-key-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.take-key-tick {
+  width: 2px;
+  height: 11px;
+  display: inline-block;
+}
+.take-key-bar {
+  width: 11px;
+  height: 2px;
+  display: inline-block;
 }
 
 /* Settings drawer */
@@ -694,6 +875,10 @@ a:hover {
   color: oklch(20% 0.015 260);
   text-align: center;
 }
+.file-btn.full {
+  flex: none;
+  width: 100%;
+}
 .export-col {
   display: flex;
   flex-direction: column;
@@ -701,7 +886,13 @@ a:hover {
 }
 .small-note {
   font-size: 10px;
+  line-height: 1.5;
   color: oklch(55% 0.02 260);
+}
+.tap-target-name {
+  font-size: 11px;
+  font-weight: 700;
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
 }
 
 /* Layout wrapper: main row + optional bottom insights strip */

--- a/dut-dut/src/styles.css
+++ b/dut-dut/src/styles.css
@@ -1083,6 +1083,96 @@ a:hover {
   z-index: 40;
 }
 
+/* Explain-elsewhere modal */
+.explain-modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(580px, calc(100% - 32px));
+  max-height: calc(100% - 48px);
+  background: oklch(98% 0.006 80);
+  border: 1px solid oklch(85% 0.012 80);
+  border-radius: 14px;
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+  z-index: 21;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.explain-body {
+  flex: 1;
+  overflow: auto;
+  padding: 14px 18px 18px;
+}
+.explain-disclosure {
+  border: 1.5px solid oklch(72% 0.12 85);
+  background: oklch(97% 0.03 85);
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.explain-disclosure-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: oklch(20% 0.015 260);
+}
+.explain-disclosure ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.explain-disclosure li {
+  font-size: 11px;
+  line-height: 1.5;
+  color: oklch(35% 0.02 260);
+}
+.explain-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  margin-bottom: 16px;
+}
+.explain-control {
+  display: flex;
+  flex-direction: column;
+}
+.explain-preview {
+  margin: 0 0 6px;
+  max-height: 260px;
+  overflow: auto;
+  background: oklch(95% 0.008 80);
+  border: 1px solid oklch(85% 0.012 80);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-size: 10.5px;
+  line-height: 1.5;
+  color: oklch(30% 0.02 260);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.explain-dests {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.explain-status {
+  margin-top: 12px;
+  border: 1.5px solid oklch(58% 0.16 235);
+  background: oklch(96% 0.02 235);
+  border-radius: 8px;
+  padding: 9px 12px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: oklch(30% 0.03 260);
+}
+
 /* Footer credit bar */
 .footer-bar {
   flex: 0 0 auto;

--- a/dut-dut/vite.config.js
+++ b/dut-dut/vite.config.js
@@ -5,5 +5,6 @@ export default defineConfig({
   plugins: [react()],
   // Relative asset paths so the built dist/ works from any URL (Netlify, GitHub Pages subfolder, file://)
   base: './',
-  server: { port: 5174, open: true },
+  // PORT lets more than one dev session run at once without colliding.
+  server: { port: Number(process.env.PORT) || 5174, open: true },
 });


### PR DESCRIPTION
## What changed

The design's "Ask Claude to explain this pattern" button was effectively dead code — it called `window.claude.complete`, which only exists inside a Claude artifact, so in any normal deployment it never rendered. This makes it real, without the project hosting inference.

Instead of calling an LLM, the app builds a **portable, self-describing context envelope** and hands it to whichever assistant the user already pays for.

- **`insights-engine.js`** — `buildCadenceContext` + `renderContextMarkdown`, and `LEVELS` (New to this / I play / Go deeper) which vary *only* the closing ask. `buildLLMPrompt` remains as a back-compat wrapper for the in-artifact path.
- **`handoff.js`** — destination registry (Claude / ChatGPT / Gemini) with a URL-length guard.
- **`ExplainModal.jsx`** — level + scope controls, a preview of the exact text, and five destinations including copy and download.
- **`download.js`** — `downloadBlob` extracted dependency-free (see bundling note below).

## Why a handoff instead of a built-in AI button

A Claude Pro/Max or ChatGPT Plus subscription **cannot be called from code** — only separately-metered API credits can, and most people using a drumline tool will never have an API key. Sending the text into the chat UI where the user is already signed in is the only route that actually reaches the subscription they already pay for. BYO-API-key was considered and rejected: it doesn't reach the subscription, and a key in `localStorage` is a real liability.

A side benefit worth protecting: **the app makes no network requests of its own.** Nothing leaves the browser until the user deliberately sends it.

## The envelope carries two things the old prompt dropped

Both landed in `9141bec` and would have produced misleading explanations:

1. **Per-part subdivisions** — voices can now use different subdivisions on the same beat, so lines have unequal character counts. Beats are bracket-marked (`[...]` triplet, `(..)` eighths, bare = 16ths) and each voice states its own subdivisions.
2. **Live-take timing** — previously ignored entirely. Now reports notes played by hand, average and worst deviation in ms, and which beats are *consistently* off. That's coaching material the rules engine structurally cannot produce.

## Ethics posture

Guardrails, not gates. The preview box shows byte-for-byte what will be sent (verified). A first-run notice covers what's shared, that it spends *the user's* credits, and that assistants set their own age minimums (claude.ai 18+, most others 13+). Nothing is blocked. The free Insights engine remains the primary teaching surface — no account, no AI, no age gate.

## Notes for review

- ⚠️ **This PR contains two commits.** `9141bec` (per-part subdivisions + live play-along) was committed locally but never pushed and has no PR of its own, and this feature depends on it. Happy to split it out if you'd rather review them separately.
- **`URL_LIMIT` is 4000, not the conventional ~2000.** Real payloads encode to ~3,300–3,600, so a 2k ceiling would make every send fall back to copy and render the vendor buttons pointless. 4k is well inside browser limits and under Apache's 8190-byte request line; since these destinations are SPAs reading `?q=` client-side, over-length surfaces as a visible 414 rather than silent truncation. Reasoning is in the code comment.
- **Bundling trap, hit twice:** a static import from an eagerly-loaded module collapses the lazy chunks. `handoff.js` importing `export-utils.js` pushed the main bundle 233 KB → 280 KB; `ExplainModal` importing `LEVELS` did the same to `insights-engine`. Fixed via `download.js` and prop-passing. All chunks lazy again, main bundle 251 KB.
- **Not verified, needs your session:** whether each vendor's `?q=` parameter actually prefills. They're undocumented and can change. Failure degrades to an empty chat with the text already on the clipboard.
- Verified: copy and download byte-match the preview; level switching changes only the ask; scope swaps section↔cadence; the length guard opens-then-copies in the right order for all three vendors; disclosure and level persist across reload; live-take math checked against hand-computed offsets; artifact path still works. Clean build, no console errors.
- 10 untracked screenshots in `dut-dut/assets/` were deliberately left out to keep this branch scoped to the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)